### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In order to generate the verifier contract, we also need to first get the KZG tr
 
 * Download the params
 ```shell
-$ sh scripts/download-params.sh
+$ bash scripts/download-params.sh
 ```
 
 * Generate the verifier contract:


### PR DESCRIPTION
The sh shell is not guaranteed to be Bash; it’s often dash on systems like Ubuntu, which does not support arrays.