### PR TITLE
feat: v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types"
 version = "0.8.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
  "alloy-primitives 1.4.1",
  "base64 0.22.1",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-base"
 version = "0.8.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
  "alloy-primitives 1.4.1",
  "alloy-serde 1.1.2",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-batch"
 version = "0.8.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
  "alloy-primitives 1.4.1",
  "c-kzg",
@@ -9365,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-bundle"
 version = "0.8.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
  "scroll-zkvm-types-base",
  "serde",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-chunk"
 version = "0.8.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 1.4.1",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.8.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "abi_stable"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6512d3eb05ffe5004c59c206de7f99c34951504056ce23fc953842f12c445"
+dependencies = [
+ "abi_stable_derive",
+ "abi_stable_shared",
+ "const_panic",
+ "core_extensions",
+ "crossbeam-channel",
+ "generational-arena",
+ "libloading",
+ "lock_api",
+ "parking_lot",
+ "paste",
+ "repr_offset",
+ "rustc_version 0.4.1",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "abi_stable_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7178468b407a4ee10e881bc7a328a65e739f0863615cca4429d43916b05e898"
+dependencies = [
+ "abi_stable_shared",
+ "as_derive_utils",
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 1.0.109",
+ "typed-arena",
+]
+
+[[package]]
+name = "abi_stable_shared"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b5df7688c123e63f4d4d649cba63f2967ba7f7861b1664fca3f77d3dad2b63"
+dependencies = [
+ "core_extensions",
+]
+
+[[package]]
 name = "addchain"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,7 +446,6 @@ dependencies = [
  "paste",
  "proptest",
  "rand 0.9.2",
- "rkyv",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -1064,6 +1111,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "as_derive_utils"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff3c96645900a44cf11941c111bd08a6573b0e2f9f69bc9264b179d8fae753c4"
+dependencies = [
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1429,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "blstrs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "pairing 0.23.0",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+]
+
+[[package]]
 name = "bon"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,29 +1519,6 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
-
-[[package]]
-name = "bytecheck"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "rancor",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
 
 [[package]]
 name = "bytemuck"
@@ -1666,7 +1718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1705,6 +1757,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -1749,6 +1810,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_extensions"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bb5e5d0269fd4f739ea6cedaf29c16d81c27a7ce7582008e90eb50dcd57003"
+dependencies = [
+ "core_extensions_proc_macros",
+]
+
+[[package]]
+name = "core_extensions_proc_macros"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533d38ecd2709b7608fb8e18e4504deb99e9a72879e6aa66373a76d8dc4259ea"
 
 [[package]]
 name = "cpufeatures"
@@ -2310,7 +2386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2738,6 +2814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
+name = "generational-arena"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,7 +2937,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.1",
+ "rand 0.8.5",
  "rand_core 0.6.4",
+ "rand_xorshift 0.3.0",
  "subtle",
 ]
 
@@ -2913,7 +3000,7 @@ dependencies = [
  "crossbeam",
  "ff 0.13.1",
  "group 0.13.0",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.11.0",
  "maybe-rayon",
  "pairing 0.23.0",
@@ -3014,6 +3101,33 @@ name = "halo2curves-axiom"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0cd39c0df23c8b72cb7158ccb106341b078d5019b5478b3bfdaf14e898177d3"
+dependencies = [
+ "blake2b_simd",
+ "digest 0.10.7",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "hex",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "pairing 0.23.0",
+ "pasta_curves 0.5.1",
+ "paste",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rayon",
+ "serde",
+ "serde_arrays",
+ "sha2 0.10.9",
+ "static_assertions",
+ "subtle",
+ "unroll",
+]
+
+[[package]]
+name = "halo2curves-axiom"
+version = "0.7.2"
+source = "git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2#3a65a710e27fe03711f6fb4fc0c4469ae351974a"
 dependencies = [
  "blake2b_simd",
  "digest 0.10.7",
@@ -3346,7 +3460,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -3693,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -3701,11 +3815,11 @@ dependencies = [
  "hex-literal",
  "num-bigint 0.4.6",
  "once_cell",
- "openvm 1.4.1",
- "openvm-algebra-guest 1.4.1",
- "openvm-algebra-moduli-macros 1.4.1",
- "openvm-ecc-guest 1.4.1",
- "openvm-ecc-sw-macros 1.4.1",
+ "openvm 1.6.0",
+ "openvm-algebra-guest 1.6.0",
+ "openvm-algebra-moduli-macros 1.6.0",
+ "openvm-ecc-guest 1.6.0",
+ "openvm-ecc-sw-macros 1.6.0",
  "serde",
 ]
 
@@ -3764,7 +3878,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3772,6 +3886,16 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libm"
@@ -4030,26 +4154,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "munge"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
-dependencies = [
- "munge_macro",
-]
-
-[[package]]
-name = "munge_macro"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -4422,16 +4526,16 @@ dependencies = [
 
 [[package]]
 name = "openvm"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.16",
  "getrandom 0.3.4",
  "num-bigint 0.4.6",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "openvm-platform 1.4.1",
- "openvm-rv32im-guest 1.4.1",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
+ "openvm-platform 1.6.0",
+ "openvm-rv32im-guest 1.6.0",
  "serde",
 ]
 
@@ -4444,7 +4548,7 @@ dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-algebra-transpiler 1.4.0",
@@ -4466,28 +4570,29 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
+ "blstrs",
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm-algebra-transpiler 1.4.1",
- "openvm-circuit 1.4.1",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-circuit-primitives-derive 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-mod-circuit-builder 1.4.1",
- "openvm-rv32-adapters 1.4.1",
- "openvm-rv32im-circuit 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "rand 0.8.5",
+ "openvm-algebra-transpiler 1.6.0",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-circuit-primitives-derive 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-mod-circuit-builder 1.6.0",
+ "openvm-rv32-adapters 1.6.0",
+ "openvm-rv32im-circuit 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "rand 0.9.2",
  "serde",
  "serde_with",
  "strum 0.26.3",
@@ -4505,10 +4610,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-complex-macros"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-macros-common 1.4.1",
+ "openvm-macros-common 1.6.0",
  "quote",
  "syn 2.0.110",
 ]
@@ -4518,7 +4623,7 @@ name = "openvm-algebra-guest"
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.4.6",
  "once_cell",
  "openvm-algebra-complex-macros 1.4.0",
@@ -4531,16 +4636,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "num-bigint 0.4.6",
  "once_cell",
- "openvm-algebra-complex-macros 1.4.1",
- "openvm-algebra-moduli-macros 1.4.1",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "openvm-rv32im-guest 1.4.1",
+ "openvm-algebra-complex-macros 1.6.0",
+ "openvm-algebra-moduli-macros 1.6.0",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
+ "openvm-rv32im-guest 1.6.0",
  "serde-big-array",
  "strum_macros 0.26.4",
 ]
@@ -4559,12 +4664,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
- "openvm-macros-common 1.4.1",
+ "openvm-macros-common 1.6.0",
  "quote",
  "syn 2.0.110",
 ]
@@ -4585,14 +4690,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-algebra-guest 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-instructions-derive 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-transpiler 1.4.1",
+ "openvm-algebra-guest 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-instructions-derive 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-transpiler 1.6.0",
  "rrs-lib",
  "strum 0.26.3",
 ]
@@ -4622,24 +4727,24 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "openvm-bigint-transpiler 1.4.1",
- "openvm-circuit 1.4.1",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-circuit-primitives-derive 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-rv32-adapters 1.4.1",
- "openvm-rv32im-circuit 1.4.1",
- "openvm-rv32im-transpiler 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "rand 0.8.5",
+ "openvm-bigint-transpiler 1.6.0",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-circuit-primitives-derive 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-rv32-adapters 1.6.0",
+ "openvm-rv32im-circuit 1.6.0",
+ "openvm-rv32im-transpiler 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "rand 0.9.2",
  "serde",
 ]
 
@@ -4654,10 +4759,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-platform 1.4.1",
+ "openvm-platform 1.6.0",
  "strum_macros 0.26.4",
 ]
 
@@ -4678,15 +4783,15 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-bigint-guest 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-instructions-derive 1.4.1",
- "openvm-rv32im-transpiler 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-transpiler 1.4.1",
+ "openvm-bigint-guest 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-instructions-derive 1.6.0",
+ "openvm-rv32im-transpiler 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-transpiler 1.6.0",
  "rrs-lib",
  "strum 0.26.3",
 ]
@@ -4705,12 +4810,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cargo_metadata",
  "eyre",
- "openvm-platform 1.4.1",
+ "openvm-platform 1.6.0",
  "serde",
  "serde_json",
 ]
@@ -4739,8 +4844,8 @@ dependencies = [
  "openvm-poseidon2-air 1.4.0",
  "openvm-stark-backend 1.2.0",
  "openvm-stark-sdk 1.2.0",
- "p3-baby-bear",
- "p3-field",
+ "p3-baby-bear 0.1.0",
+ "p3-field 0.1.0",
  "rand 0.8.5",
  "rustc-hash 2.1.1",
  "serde",
@@ -4752,9 +4857,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
+ "abi_stable",
  "backtrace",
  "cfg-if",
  "dashmap",
@@ -4767,16 +4873,16 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "memmap2",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-circuit-primitives-derive 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-poseidon2-air 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "p3-baby-bear",
- "p3-field",
- "rand 0.8.5",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-circuit-primitives-derive 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-poseidon2-air 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "p3-baby-bear 0.4.3",
+ "p3-field 0.4.3",
+ "rand 0.9.2",
  "rustc-hash 2.1.1",
  "serde",
  "serde-big-array",
@@ -4798,8 +4904,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -4825,17 +4931,17 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm-circuit-primitives-derive 1.4.1",
- "openvm-cuda-builder 1.2.1",
- "openvm-stark-backend 1.2.1",
- "rand 0.8.5",
+ "openvm-circuit-primitives-derive 1.6.0",
+ "openvm-cuda-builder 1.4.0",
+ "openvm-stark-backend 1.4.0",
+ "rand 0.9.2",
  "tracing",
 ]
 
@@ -4851,8 +4957,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4876,15 +4982,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derivative",
- "openvm-circuit 1.4.1",
- "openvm-native-compiler 1.4.1",
- "openvm-native-recursion 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
+ "openvm-circuit 1.6.0",
+ "openvm-native-compiler 1.6.0",
+ "openvm-native-recursion 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "p3-bn254",
  "serde",
  "static_assertions",
 ]
@@ -4900,8 +5007,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-cuda-builder"
-version = "1.2.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.1#dde6cdaf105cc57d1609fd49568c7bce0a066cc2"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.4.0#2d4c6da0c84f43b15fcdac84ce13fd2325148c66"
 dependencies = [
  "cc",
  "glob",
@@ -4920,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4935,7 +5042,7 @@ dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",
  "lazy_static",
  "num-bigint 0.4.6",
@@ -4958,28 +5065,29 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
+ "blstrs",
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "hex-literal",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-traits",
  "once_cell",
- "openvm-algebra-circuit 1.4.1",
- "openvm-circuit 1.4.1",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-ecc-transpiler 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-mod-circuit-builder 1.4.1",
- "openvm-rv32-adapters 1.4.1",
- "openvm-stark-backend 1.2.1",
- "rand 0.8.5",
+ "openvm-algebra-circuit 1.6.0",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-ecc-transpiler 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-mod-circuit-builder 1.6.0",
+ "openvm-rv32-adapters 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "rand 0.9.2",
  "serde",
  "serde_with",
  "strum 0.26.3",
@@ -4993,7 +5101,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "group 0.13.0",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "openvm 1.4.0",
  "openvm-algebra-guest 1.4.0",
@@ -5006,19 +5114,19 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "group 0.13.0",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "once_cell",
- "openvm 1.4.1",
- "openvm-algebra-guest 1.4.1",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "openvm-ecc-sw-macros 1.4.1",
- "openvm-rv32im-guest 1.4.1",
+ "openvm 1.6.0",
+ "openvm-algebra-guest 1.6.0",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
+ "openvm-ecc-sw-macros 1.6.0",
+ "openvm-rv32im-guest 1.6.0",
  "serde",
  "strum_macros 0.26.4",
 ]
@@ -5035,10 +5143,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-macros-common 1.4.1",
+ "openvm-macros-common 1.6.0",
  "quote",
  "syn 2.0.110",
 ]
@@ -5059,14 +5167,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-ecc-guest 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-instructions-derive 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-transpiler 1.4.1",
+ "openvm-ecc-guest 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-instructions-derive 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-transpiler 1.6.0",
  "rrs-lib",
  "strum 0.26.3",
 ]
@@ -5090,16 +5198,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm-instructions-derive 1.4.1",
- "openvm-stark-backend 1.2.1",
+ "openvm-instructions-derive 1.6.0",
+ "openvm-stark-backend 1.4.0",
  "serde",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -5116,8 +5224,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "quote",
  "syn 2.0.110",
@@ -5141,7 +5249,7 @@ dependencies = [
  "openvm-rv32im-circuit 1.4.0",
  "openvm-stark-backend 1.2.0",
  "openvm-stark-sdk 1.2.0",
- "p3-keccak-air",
+ "p3-keccak-air 0.1.0",
  "rand 0.8.5",
  "serde",
  "strum 0.26.3",
@@ -5150,24 +5258,24 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "itertools 0.14.0",
- "openvm-circuit 1.4.1",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-circuit-primitives-derive 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-keccak256-transpiler 1.4.1",
- "openvm-rv32im-circuit 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "p3-keccak-air",
- "rand 0.8.5",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-circuit-primitives-derive 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-keccak256-transpiler 1.6.0",
+ "openvm-rv32im-circuit 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "p3-keccak-air 0.4.3",
+ "rand 0.9.2",
  "serde",
  "strum 0.26.3",
  "tiny-keccak",
@@ -5183,10 +5291,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-platform 1.4.1",
+ "openvm-platform 1.6.0",
 ]
 
 [[package]]
@@ -5205,14 +5313,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.4.1",
- "openvm-instructions-derive 1.4.1",
- "openvm-keccak256-guest 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-transpiler 1.4.1",
+ "openvm-instructions 1.6.0",
+ "openvm-instructions-derive 1.6.0",
+ "openvm-keccak256-guest 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-transpiler 1.6.0",
  "rrs-lib",
  "strum 0.26.3",
 ]
@@ -5227,8 +5335,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "syn 2.0.110",
 ]
@@ -5253,19 +5361,20 @@ dependencies = [
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm-circuit 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-cuda-builder 1.2.1",
- "openvm-instructions 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-cuda-builder 1.4.0",
+ "openvm-instructions 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
  "rand 0.8.5",
+ "rand 0.9.2",
  "tracing",
 ]
 
@@ -5290,7 +5399,7 @@ dependencies = [
  "openvm-rv32im-transpiler 1.4.0",
  "openvm-stark-backend 1.2.0",
  "openvm-stark-sdk 1.2.0",
- "p3-field",
+ "p3-field 0.1.0",
  "rand 0.8.5",
  "serde",
  "static_assertions",
@@ -5299,27 +5408,27 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
  "itertools 0.14.0",
- "openvm-circuit 1.4.1",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-circuit-primitives-derive 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-native-compiler 1.4.1",
- "openvm-poseidon2-air 1.4.1",
- "openvm-rv32im-circuit 1.4.1",
- "openvm-rv32im-transpiler 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "p3-field",
- "rand 0.8.5",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-circuit-primitives-derive 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-native-compiler 1.6.0",
+ "openvm-poseidon2-air 1.6.0",
+ "openvm-rv32im-circuit 1.6.0",
+ "openvm-rv32im-transpiler 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "p3-field 0.4.3",
+ "rand 0.9.2",
  "serde",
  "static_assertions",
  "strum 0.26.3",
@@ -5350,20 +5459,20 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-integer",
- "openvm-circuit 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-instructions-derive 1.4.1",
- "openvm-native-compiler-derive 1.4.1",
- "openvm-rv32im-transpiler 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
+ "openvm-circuit 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-instructions-derive 1.6.0",
+ "openvm-native-compiler-derive 1.6.0",
+ "openvm-rv32im-transpiler 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
  "serde",
  "snark-verifier-sdk",
  "strum 0.26.3",
@@ -5382,8 +5491,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "quote",
  "syn 2.0.110",
@@ -5404,10 +5513,10 @@ dependencies = [
  "openvm-native-compiler-derive 1.4.0",
  "openvm-stark-backend 1.2.0",
  "openvm-stark-sdk 1.2.0",
- "p3-dft",
- "p3-fri",
- "p3-merkle-tree",
- "p3-symmetric",
+ "p3-dft 0.1.0",
+ "p3-fri 0.1.0",
+ "p3-merkle-tree 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5418,24 +5527,25 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
  "lazy_static",
  "once_cell",
- "openvm-circuit 1.4.1",
- "openvm-native-circuit 1.4.1",
- "openvm-native-compiler 1.4.1",
- "openvm-native-compiler-derive 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "p3-dft",
- "p3-fri",
- "p3-merkle-tree",
- "p3-symmetric",
+ "openvm-circuit 1.6.0",
+ "openvm-native-circuit 1.6.0",
+ "openvm-native-compiler 1.6.0",
+ "openvm-native-compiler-derive 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "p3-dft 0.4.3",
+ "p3-fri 0.4.3",
+ "p3-merkle-tree 0.4.3",
+ "p3-symmetric 0.4.3",
  "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -5450,41 +5560,40 @@ source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f7364
 dependencies = [
  "openvm-instructions 1.4.0",
  "openvm-transpiler 1.4.0",
- "p3-field",
+ "p3-field 0.1.0",
 ]
 
 [[package]]
 name = "openvm-native-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.4.1",
- "openvm-transpiler 1.4.1",
- "p3-field",
+ "openvm-instructions 1.6.0",
+ "openvm-transpiler 1.6.0",
+ "p3-field 0.4.3",
 ]
 
 [[package]]
 name = "openvm-pairing"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "group 0.13.0",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "hex-literal",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm 1.4.1",
- "openvm-algebra-complex-macros 1.4.1",
- "openvm-algebra-guest 1.4.1",
- "openvm-algebra-moduli-macros 1.4.1",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "openvm-ecc-guest 1.4.1",
- "openvm-ecc-sw-macros 1.4.1",
- "openvm-pairing-guest 1.4.1",
- "openvm-platform 1.4.1",
- "openvm-rv32im-guest 1.4.1",
- "rand 0.8.5",
+ "openvm 1.6.0",
+ "openvm-algebra-complex-macros 1.6.0",
+ "openvm-algebra-guest 1.6.0",
+ "openvm-algebra-moduli-macros 1.6.0",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
+ "openvm-ecc-guest 1.6.0",
+ "openvm-ecc-sw-macros 1.6.0",
+ "openvm-pairing-guest 1.6.0",
+ "openvm-platform 1.6.0",
+ "openvm-rv32im-guest 1.6.0",
  "serde",
 ]
 
@@ -5497,7 +5606,7 @@ dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-algebra-circuit 1.4.0",
@@ -5519,29 +5628,29 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm-algebra-circuit 1.4.1",
- "openvm-circuit 1.4.1",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-ecc-circuit 1.4.1",
- "openvm-ecc-guest 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-mod-circuit-builder 1.4.1",
- "openvm-pairing-guest 1.4.1",
- "openvm-pairing-transpiler 1.4.1",
- "openvm-rv32im-circuit 1.4.1",
- "openvm-stark-backend 1.2.1",
- "rand 0.8.5",
+ "openvm-algebra-circuit 1.6.0",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-ecc-circuit 1.6.0",
+ "openvm-ecc-guest 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-mod-circuit-builder 1.6.0",
+ "openvm-pairing-guest 1.6.0",
+ "openvm-pairing-transpiler 1.6.0",
+ "openvm-rv32im-circuit 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "rand 0.9.2",
  "serde",
  "strum 0.26.3",
 ]
@@ -5551,7 +5660,7 @@ name = "openvm-pairing-guest"
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",
  "itertools 0.14.0",
  "lazy_static",
@@ -5569,21 +5678,21 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "halo2curves-axiom",
+ "blstrs",
+ "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "hex-literal",
  "itertools 0.14.0",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm 1.4.1",
- "openvm-algebra-guest 1.4.1",
- "openvm-algebra-moduli-macros 1.4.1",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "openvm-ecc-guest 1.4.1",
- "rand 0.8.5",
+ "openvm 1.6.0",
+ "openvm-algebra-guest 1.6.0",
+ "openvm-algebra-moduli-macros 1.6.0",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
+ "openvm-ecc-guest 1.6.0",
  "serde",
  "strum_macros 0.26.4",
 ]
@@ -5603,13 +5712,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.4.1",
- "openvm-pairing-guest 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-transpiler 1.4.1",
+ "openvm-instructions 1.6.0",
+ "openvm-pairing-guest 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-transpiler 1.6.0",
  "rrs-lib",
  "strum 0.26.3",
 ]
@@ -5626,12 +5735,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "libm",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "openvm-rv32im-guest 1.4.1",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
+ "openvm-rv32im-guest 1.6.0",
 ]
 
 [[package]]
@@ -5644,29 +5753,28 @@ dependencies = [
  "openvm-cuda-builder 1.2.0",
  "openvm-stark-backend 1.2.0",
  "openvm-stark-sdk 1.2.0",
- "p3-monty-31",
- "p3-poseidon2",
- "p3-poseidon2-air",
- "p3-symmetric",
+ "p3-monty-31 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-poseidon2-air 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
  "zkhash",
 ]
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derivative",
  "lazy_static",
- "openvm-cuda-builder 1.2.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "p3-monty-31",
- "p3-poseidon2",
- "p3-poseidon2-air",
- "p3-symmetric",
- "rand 0.8.5",
+ "openvm-cuda-builder 1.4.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "p3-poseidon2 0.4.3",
+ "p3-poseidon2-air 0.4.3",
+ "p3-symmetric 0.4.3",
+ "rand 0.9.2",
  "zkhash",
 ]
 
@@ -5689,19 +5797,19 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
- "openvm-circuit 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-circuit-primitives-derive 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-rv32im-circuit 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "rand 0.8.5",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-circuit-primitives-derive 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-rv32im-circuit 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -5729,8 +5837,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5738,14 +5846,14 @@ dependencies = [
  "eyre",
  "num-bigint 0.4.6",
  "num-integer",
- "openvm-circuit 1.4.1",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-circuit-primitives-derive 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-rv32im-transpiler 1.4.1",
- "openvm-stark-backend 1.2.1",
- "rand 0.8.5",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-circuit-primitives-derive 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-rv32im-transpiler 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "rand 0.9.2",
  "serde",
  "strum 0.26.3",
 ]
@@ -5756,17 +5864,17 @@ version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.0)",
- "p3-field",
+ "p3-field 0.1.0",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "p3-field",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
+ "p3-field 0.4.3",
  "strum_macros 0.26.4",
 ]
 
@@ -5788,14 +5896,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.4.1",
- "openvm-instructions-derive 1.4.1",
- "openvm-rv32im-guest 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-transpiler 1.4.1",
+ "openvm-instructions 1.6.0",
+ "openvm-instructions-derive 1.6.0",
+ "openvm-rv32im-guest 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-transpiler 1.6.0",
  "rrs-lib",
  "serde",
  "strum 0.26.3",
@@ -5846,7 +5954,7 @@ dependencies = [
  "openvm-stark-backend 1.2.0",
  "openvm-stark-sdk 1.2.0",
  "openvm-transpiler 1.4.0",
- "p3-fri",
+ "p3-fri 0.1.0",
  "rand 0.8.5",
  "rrs-lib",
  "serde",
@@ -5862,8 +5970,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "bitcode",
  "bon",
@@ -5877,33 +5985,34 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "num-bigint 0.4.6",
- "openvm 1.4.1",
- "openvm-algebra-circuit 1.4.1",
- "openvm-algebra-transpiler 1.4.1",
- "openvm-bigint-circuit 1.4.1",
- "openvm-bigint-transpiler 1.4.1",
- "openvm-build 1.4.1",
- "openvm-circuit 1.4.1",
- "openvm-continuations 1.4.1",
- "openvm-ecc-circuit 1.4.1",
- "openvm-ecc-transpiler 1.4.1",
- "openvm-keccak256-circuit 1.4.1",
- "openvm-keccak256-transpiler 1.4.1",
- "openvm-native-circuit 1.4.1",
- "openvm-native-compiler 1.4.1",
- "openvm-native-recursion 1.4.1",
- "openvm-native-transpiler 1.4.1",
- "openvm-pairing-circuit 1.4.1",
- "openvm-pairing-transpiler 1.4.1",
- "openvm-rv32im-circuit 1.4.1",
- "openvm-rv32im-transpiler 1.4.1",
- "openvm-sha256-circuit 1.4.1",
- "openvm-sha256-transpiler 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "openvm-transpiler 1.4.1",
- "p3-fri",
- "rand 0.8.5",
+ "openvm 1.6.0",
+ "openvm-algebra-circuit 1.6.0",
+ "openvm-algebra-transpiler 1.6.0",
+ "openvm-bigint-circuit 1.6.0",
+ "openvm-bigint-transpiler 1.6.0",
+ "openvm-build 1.6.0",
+ "openvm-circuit 1.6.0",
+ "openvm-continuations 1.6.0",
+ "openvm-ecc-circuit 1.6.0",
+ "openvm-ecc-transpiler 1.6.0",
+ "openvm-keccak256-circuit 1.6.0",
+ "openvm-keccak256-transpiler 1.6.0",
+ "openvm-native-circuit 1.6.0",
+ "openvm-native-compiler 1.6.0",
+ "openvm-native-recursion 1.6.0",
+ "openvm-native-transpiler 1.6.0",
+ "openvm-pairing-circuit 1.6.0",
+ "openvm-pairing-transpiler 1.6.0",
+ "openvm-rv32im-circuit 1.6.0",
+ "openvm-rv32im-transpiler 1.6.0",
+ "openvm-sha256-circuit 1.6.0",
+ "openvm-sha256-transpiler 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "openvm-transpiler 1.6.0",
+ "p3-bn254",
+ "p3-fri 0.4.3",
+ "rand 0.9.2",
  "rrs-lib",
  "serde",
  "serde_json",
@@ -5918,10 +6027,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha2"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-sha256-guest 1.4.1",
+ "openvm-sha256-guest 1.6.0",
  "sha2 0.10.9",
 ]
 
@@ -5938,12 +6047,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-circuit-primitives 1.4.1",
- "openvm-stark-backend 1.2.1",
- "rand 0.8.5",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "rand 0.9.2",
  "sha2 0.10.9",
 ]
 
@@ -5972,22 +6081,22 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "openvm-circuit 1.4.1",
- "openvm-circuit-derive 1.4.1",
- "openvm-circuit-primitives 1.4.1",
- "openvm-instructions 1.4.1",
- "openvm-rv32im-circuit 1.4.1",
- "openvm-sha256-air 1.4.1",
- "openvm-sha256-transpiler 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-stark-sdk 1.2.1",
- "rand 0.8.5",
+ "openvm-circuit 1.6.0",
+ "openvm-circuit-derive 1.6.0",
+ "openvm-circuit-primitives 1.6.0",
+ "openvm-instructions 1.6.0",
+ "openvm-rv32im-circuit 1.6.0",
+ "openvm-sha256-air 1.6.0",
+ "openvm-sha256-transpiler 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-stark-sdk 1.4.0",
+ "rand 0.9.2",
  "serde",
  "sha2 0.10.9",
  "strum 0.26.3",
@@ -6003,10 +6112,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-platform 1.4.1",
+ "openvm-platform 1.6.0",
 ]
 
 [[package]]
@@ -6025,14 +6134,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.4.1",
- "openvm-instructions-derive 1.4.1",
- "openvm-sha256-guest 1.4.1",
- "openvm-stark-backend 1.2.1",
- "openvm-transpiler 1.4.1",
+ "openvm-instructions 1.6.0",
+ "openvm-instructions-derive 1.6.0",
+ "openvm-sha256-guest 1.6.0",
+ "openvm-stark-backend 1.4.0",
+ "openvm-transpiler 1.6.0",
  "rrs-lib",
  "strum 0.26.3",
 ]
@@ -6047,14 +6156,14 @@ dependencies = [
  "derivative",
  "derive-new 0.7.0",
  "itertools 0.14.0",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-air 0.1.0",
+ "p3-challenger 0.1.0",
+ "p3-commit 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
  "p3-uni-stark",
- "p3-util",
+ "p3-util 0.1.0",
  "rayon",
  "rustc-hash 2.1.1",
  "serde",
@@ -6073,14 +6182,40 @@ dependencies = [
  "derive-new 0.7.0",
  "eyre",
  "itertools 0.14.0",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-air 0.1.0",
+ "p3-challenger 0.1.0",
+ "p3-commit 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
  "p3-uni-stark",
- "p3-util",
+ "p3-util 0.1.0",
+ "rayon",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "openvm-stark-backend"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.4.0#2d4c6da0c84f43b15fcdac84ce13fd2325148c66"
+dependencies = [
+ "bitcode",
+ "cfg-if",
+ "derivative",
+ "derive-new 0.7.0",
+ "eyre",
+ "itertools 0.14.0",
+ "p3-air 0.4.3",
+ "p3-challenger 0.4.3",
+ "p3-commit 0.4.3",
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-util 0.4.3",
  "rayon",
  "rustc-hash 2.1.1",
  "serde",
@@ -6103,18 +6238,18 @@ dependencies = [
  "metrics-tracing-context",
  "metrics-util",
  "openvm-stark-backend 1.2.0",
- "p3-baby-bear",
- "p3-blake3",
+ "p3-baby-bear 0.1.0",
+ "p3-blake3 0.1.0",
  "p3-bn254-fr",
- "p3-dft",
- "p3-fri",
- "p3-goldilocks",
- "p3-keccak",
- "p3-koala-bear",
- "p3-merkle-tree",
- "p3-poseidon",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-dft 0.1.0",
+ "p3-fri 0.1.0",
+ "p3-goldilocks 0.1.0",
+ "p3-keccak 0.1.0",
+ "p3-koala-bear 0.1.0",
+ "p3-merkle-tree 0.1.0",
+ "p3-poseidon 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6140,19 +6275,57 @@ dependencies = [
  "metrics-tracing-context",
  "metrics-util",
  "openvm-stark-backend 1.2.1",
- "p3-baby-bear",
- "p3-blake3",
+ "p3-baby-bear 0.1.0",
+ "p3-blake3 0.1.0",
  "p3-bn254-fr",
- "p3-dft",
- "p3-fri",
- "p3-goldilocks",
- "p3-keccak",
- "p3-koala-bear",
- "p3-merkle-tree",
- "p3-poseidon",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-dft 0.1.0",
+ "p3-fri 0.1.0",
+ "p3-goldilocks 0.1.0",
+ "p3-keccak 0.1.0",
+ "p3-koala-bear 0.1.0",
+ "p3-merkle-tree 0.1.0",
+ "p3-poseidon 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "toml 0.8.23",
+ "tracing",
+ "tracing-forest",
+ "tracing-subscriber 0.3.20",
+ "zkhash",
+]
+
+[[package]]
+name = "openvm-stark-sdk"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.4.0#2d4c6da0c84f43b15fcdac84ce13fd2325148c66"
+dependencies = [
+ "dashmap",
+ "derivative",
+ "derive_more 1.0.0",
+ "ff 0.13.1",
+ "itertools 0.14.0",
+ "metrics",
+ "metrics-tracing-context",
+ "metrics-util",
+ "num-bigint 0.4.6",
+ "openvm-stark-backend 1.4.0",
+ "p3-baby-bear 0.4.3",
+ "p3-blake3 0.4.3",
+ "p3-bn254",
+ "p3-dft 0.4.3",
+ "p3-fri 0.4.3",
+ "p3-goldilocks 0.4.3",
+ "p3-keccak 0.4.3",
+ "p3-koala-bear 0.4.3",
+ "p3-merkle-tree 0.4.3",
+ "p3-poseidon 0.4.3",
+ "p3-poseidon2 0.4.3",
+ "p3-symmetric 0.4.3",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "static_assertions",
@@ -6179,14 +6352,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.4.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "elf",
  "eyre",
- "openvm-instructions 1.4.1",
- "openvm-platform 1.4.1",
- "openvm-stark-backend 1.2.1",
+ "openvm-instructions 1.6.0",
+ "openvm-platform 1.6.0",
+ "openvm-stark-backend 1.4.0",
  "rrs-lib",
  "thiserror 1.0.69",
 ]
@@ -6221,18 +6394,18 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "ff 0.13.1",
  "hex-literal",
  "num-bigint 0.4.6",
- "openvm 1.4.1",
- "openvm-algebra-guest 1.4.1",
- "openvm-algebra-moduli-macros 1.4.1",
- "openvm-ecc-guest 1.4.1",
- "openvm-ecc-sw-macros 1.4.1",
+ "openvm 1.6.0",
+ "openvm-algebra-guest 1.6.0",
+ "openvm-algebra-moduli-macros 1.6.0",
+ "openvm-ecc-guest 1.6.0",
+ "openvm-ecc-sw-macros 1.6.0",
  "serde",
 ]
 
@@ -6241,8 +6414,18 @@ name = "p3-air"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
- "p3-field",
- "p3-matrix",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+]
+
+[[package]]
+name = "p3-air"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daee3082e2ca0db2ac876c43c9c8fd53204b0fcb95cfe7258d21f4a925ad82c4"
+dependencies = [
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
 ]
 
 [[package]]
@@ -6250,13 +6433,28 @@ name = "p3-baby-bear"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
- "p3-field",
- "p3-mds",
- "p3-monty-31",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-monty-31 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
  "serde",
+]
+
+[[package]]
+name = "p3-baby-bear"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1a49f4d9c8b8cbdab61e25d9de1b78b3c8347dd2fb88b11d990b3efa8cdd3a"
+dependencies = [
+ "p3-challenger 0.4.3",
+ "p3-field 0.4.3",
+ "p3-mds 0.4.3",
+ "p3-monty-31 0.4.3",
+ "p3-poseidon2 0.4.3",
+ "p3-symmetric 0.4.3",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -6265,8 +6463,35 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "blake3",
- "p3-symmetric",
- "p3-util",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
+]
+
+[[package]]
+name = "p3-blake3"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f97fd783752532861bf29bac344b7c226a0d1e2151148834c43c651a5d401"
+dependencies = [
+ "blake3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
+]
+
+[[package]]
+name = "p3-bn254"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923bd91df7dd93481b4bfb53aa903d46d1a49d51160513472a5e95ca92ef1b46"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field 0.4.3",
+ "p3-poseidon2 0.4.3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
+ "paste",
+ "rand 0.9.2",
+ "serde",
 ]
 
 [[package]]
@@ -6277,9 +6502,9 @@ dependencies = [
  "ff 0.13.1",
  "halo2curves",
  "num-bigint 0.4.6",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
  "serde",
 ]
@@ -6289,10 +6514,24 @@ name = "p3-challenger"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
- "p3-field",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d2d45f5a51dc3f965e8d6da60a6c26c807e88657863d56da275eaa05ad36f1"
+dependencies = [
+ "p3-field 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-monty-31 0.4.3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
  "tracing",
 ]
 
@@ -6302,11 +6541,26 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-challenger 0.1.0",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-util 0.1.0",
+ "serde",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6d7dcb58a8f21f0e1325dc7f7699ad749878ccbe7e286e61f9d46bde2bfa88"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-challenger 0.4.3",
+ "p3-dft 0.4.3",
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-util 0.4.3",
  "serde",
 ]
 
@@ -6316,10 +6570,25 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beabb40bc8ac7f5f95870f271fb844c7e2e1ebb7f0761a8eebb2614b56c6b1c1"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-util 0.4.3",
+ "spin 0.10.0",
  "tracing",
 ]
 
@@ -6333,9 +6602,25 @@ dependencies = [
  "num-integer",
  "num-traits",
  "nums",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4819a3e4c1882431a63d4847ffa10d110017aee4cb9cf4319ca6dca191930969"
+dependencies = [
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "p3-maybe-rayon 0.4.3",
+ "p3-util 0.4.3",
+ "paste",
+ "rand 0.9.2",
  "serde",
  "tracing",
 ]
@@ -6346,16 +6631,37 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-interpolation",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-challenger 0.1.0",
+ "p3-commit 0.1.0",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-interpolation 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
  "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-fri"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca6a795cfc4180425fbf16dfdb4c9c2bfa85971dd55b5930d97b513e0835df"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-challenger 0.4.3",
+ "p3-commit 0.4.3",
+ "p3-dft 0.4.3",
+ "p3-field 0.4.3",
+ "p3-interpolation 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-util 0.4.3",
+ "rand 0.9.2",
+ "serde",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -6365,14 +6671,33 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "num-bigint 0.4.6",
- "p3-dft",
- "p3-field",
- "p3-mds",
- "p3-poseidon",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-poseidon 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c47d5c650bbeb25941b9a1fa9bfaf59b3cd202a438ea2c20892489af001399"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-challenger 0.4.3",
+ "p3-dft 0.4.3",
+ "p3-field 0.4.3",
+ "p3-mds 0.4.3",
+ "p3-poseidon2 0.4.3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
+ "paste",
+ "rand 0.9.2",
  "serde",
 ]
 
@@ -6381,10 +6706,22 @@ name = "p3-interpolation"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
+]
+
+[[package]]
+name = "p3-interpolation"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27a3696641a8f4ec990ff8c91862fb4f3b4ff29f589f78005d046023fe3550f"
+dependencies = [
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-util 0.4.3",
 ]
 
 [[package]]
@@ -6393,9 +6730,21 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "p3-keccak"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61b090fb42152d1fcb2f82227b8619b1b022f9cd4a123123dccc9c2ab75d5de"
+dependencies = [
+ "p3-field 0.4.3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
  "tiny-keccak",
 ]
 
@@ -6404,12 +6753,27 @@ name = "p3-keccak-air"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
- "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-air 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
+ "tracing",
+]
+
+[[package]]
+name = "p3-keccak-air"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4832d817455f7a4a35b598cbb8a42f1ee0430ee82df0203956c26917b2509865"
+dependencies = [
+ "p3-air 0.4.3",
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-util 0.4.3",
+ "rand 0.9.2",
  "tracing",
 ]
 
@@ -6418,13 +6782,27 @@ name = "p3-koala-bear"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
- "p3-field",
- "p3-mds",
- "p3-monty-31",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-monty-31 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
  "serde",
+]
+
+[[package]]
+name = "p3-koala-bear"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb02789fca0950e246123d652bd78e75a76e3b90a651fd88dbb215cd3e81f5a"
+dependencies = [
+ "p3-challenger 0.4.3",
+ "p3-field 0.4.3",
+ "p3-monty-31 0.4.3",
+ "p3-poseidon2 0.4.3",
+ "p3-symmetric 0.4.3",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -6433,13 +6811,28 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
  "serde",
  "tracing",
  "transpose",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6fde449bd2963d394284ec46db8c647e6a5602d90601117b76752072ab54168"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-util 0.4.3",
+ "rand 0.9.2",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -6451,17 +6844,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "p3-maybe-rayon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54afab3883d8a14676b492709d6c4e9fa535c36718b737db0817aacfaaaa11f6"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "p3-mds"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3895055d735ac96d010747b3aaabd4c2645b9fd80226960550318db2e25afb75"
+dependencies = [
+ "p3-dft 0.4.3",
+ "p3-field 0.4.3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -6470,14 +6885,33 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-commit 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
  "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-merkle-tree"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e20f61ea816e94f83ed7b8134a5e98d0cad7bd6dff226bc1da17a5143c63cb"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-commit 0.4.3",
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
+ "rand 0.9.2",
+ "serde",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -6488,14 +6922,14 @@ source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62c
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-symmetric 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -6503,14 +6937,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "p3-monty-31"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fe0be661891af1f703ceaf57334fcbd540804988984dc2b500dd99740e7c81"
+dependencies = [
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "p3-dft 0.4.3",
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-mds 0.4.3",
+ "p3-poseidon2 0.4.3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
 name = "p3-poseidon"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
- "p3-field",
- "p3-mds",
- "p3-symmetric",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-poseidon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548af7ff569975882bc411f653aba7d89a6d85813ca58ef922fd0b1ecb6b5866"
+dependencies = [
+ "p3-field 0.4.3",
+ "p3-mds 0.4.3",
+ "p3-symmetric 0.4.3",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -6519,10 +6988,23 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "gcd",
- "p3-field",
- "p3-mds",
- "p3-symmetric",
+ "p3-field 0.1.0",
+ "p3-mds 0.1.0",
+ "p3-symmetric 0.1.0",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6fc2368447576283f8b3849a36095017f25addf06eab9e33b0ce7f96b0b99d"
+dependencies = [
+ "p3-field 0.4.3",
+ "p3-mds 0.4.3",
+ "p3-symmetric 0.4.3",
+ "p3-util 0.4.3",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -6530,14 +7012,29 @@ name = "p3-poseidon2-air"
 version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
- "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-poseidon2",
- "p3-util",
+ "p3-air 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-util 0.1.0",
  "rand 0.8.5",
  "tikv-jemallocator",
+ "tracing",
+]
+
+[[package]]
+name = "p3-poseidon2-air"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80481b023f74c0f8ded5058dab8054174e8060d82d400da7b67cf7f2f0a87bc"
+dependencies = [
+ "p3-air 0.4.3",
+ "p3-field 0.4.3",
+ "p3-matrix 0.4.3",
+ "p3-maybe-rayon 0.4.3",
+ "p3-poseidon2 0.4.3",
+ "rand 0.9.2",
  "tracing",
 ]
 
@@ -6547,7 +7044,18 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
+ "p3-field 0.1.0",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14456a42a7d9e65f13999706f1bca2832175935169b3a54286e18331cf1d82f"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field 0.4.3",
  "serde",
 ]
 
@@ -6557,14 +7065,14 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-air 0.1.0",
+ "p3-challenger 0.1.0",
+ "p3-commit 0.1.0",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-util 0.1.0",
  "serde",
  "tracing",
 ]
@@ -6575,6 +7083,16 @@ version = "0.1.0"
 source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911154accf66034b0eec4452956c088f92a200b37a8225c1caed74cfbd38cc8d"
+dependencies = [
+ "serde",
+ "transpose",
 ]
 
 [[package]]
@@ -7041,26 +7559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7110,15 +7608,6 @@ checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
  "endian-type",
  "nibble_vec",
-]
-
-[[package]]
-name = "rancor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
-dependencies = [
- "ptr_meta",
 ]
 
 [[package]]
@@ -7300,12 +7789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "rend"
-version = "0.5.3"
+name = "repr_offset"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
 dependencies = [
- "bytecheck",
+ "tstr",
 ]
 
 [[package]]
@@ -8418,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "risc0-ethereum-trie"
 version = "0.1.0"
-source = "git+https://github.com/risc0/risc0-ethereum#e475fe6c8dcff92fb5e67d6556cb11ba3ab4e494"
+source = "git+https://github.com/risc0/risc0-ethereum#3aa137844818f0f44e6b2962b6eb958f26d04be7"
 dependencies = [
  "alloy-primitives 1.4.1",
  "alloy-rlp",
@@ -8428,36 +8917,6 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360b333c61ae24e5af3ae7c8660bd6b21ccd8200dbbc5d33c2454421e85b9c69"
-dependencies = [
- "bytecheck",
- "bytes",
- "hashbrown 0.16.1",
- "indexmap 2.12.1",
- "munge",
- "ptr_meta",
- "rancor",
- "rend",
- "rkyv_derive",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02f8cdd12b307ab69fe0acf4cd2249c7460eb89dce64a0febadf934ebb6a9e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -8525,7 +8984,6 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rand 0.9.2",
- "rkyv",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -8591,7 +9049,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8700,7 +9158,6 @@ dependencies = [
  "itertools 0.14.0",
  "reth-primitives-traits",
  "reth-stateless",
- "rkyv",
  "sbv-helpers",
  "sbv-primitives",
  "sbv-trie",
@@ -8736,7 +9193,6 @@ dependencies = [
  "reth-primitives",
  "reth-primitives-traits",
  "revm 30.1.1",
- "rkyv",
  "sbv-helpers",
  "serde",
 ]
@@ -8851,8 +9307,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-types"
-version = "0.7.1"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.2#3d7f13148dc99a84333c0ddc5cbcb16379ab9fb1"
+version = "0.8.0"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
 dependencies = [
  "alloy-primitives 1.4.1",
  "base64 0.22.1",
@@ -8860,9 +9316,9 @@ dependencies = [
  "eyre",
  "hex",
  "once_cell",
- "openvm-native-recursion 1.4.1",
- "openvm-sdk 1.4.1",
- "openvm-stark-sdk 1.2.1",
+ "openvm-native-recursion 1.6.0",
+ "openvm-sdk 1.6.0",
+ "openvm-stark-sdk 1.4.0",
  "sbv-primitives",
  "scroll-zkvm-types-base",
  "scroll-zkvm-types-batch",
@@ -8875,12 +9331,11 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-types-base"
-version = "0.7.1"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.2#3d7f13148dc99a84333c0ddc5cbcb16379ab9fb1"
+version = "0.8.0"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
 dependencies = [
  "alloy-primitives 1.4.1",
  "alloy-serde 1.1.2",
- "rkyv",
  "serde",
  "sha2 0.10.9",
  "sha3",
@@ -8888,20 +9343,19 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-types-batch"
-version = "0.7.1"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.2#3d7f13148dc99a84333c0ddc5cbcb16379ab9fb1"
+version = "0.8.0"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
 dependencies = [
  "alloy-primitives 1.4.1",
  "c-kzg",
- "halo2curves-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.14.0",
- "openvm 1.4.1",
- "openvm-algebra-guest 1.4.1",
- "openvm-ecc-guest 1.4.1",
+ "openvm 1.6.0",
+ "openvm-algebra-guest 1.6.0",
+ "openvm-ecc-guest 1.6.0",
  "openvm-pairing",
- "openvm-pairing-guest 1.4.1",
+ "openvm-pairing-guest 1.6.0",
  "openvm-sha2",
- "rkyv",
  "sbv-primitives",
  "scroll-zkvm-types-base",
  "serde",
@@ -8910,18 +9364,17 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-types-bundle"
-version = "0.7.1"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.2#3d7f13148dc99a84333c0ddc5cbcb16379ab9fb1"
+version = "0.8.0"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
 dependencies = [
- "rkyv",
  "scroll-zkvm-types-base",
  "serde",
 ]
 
 [[package]]
 name = "scroll-zkvm-types-chunk"
-version = "0.7.1"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.2#3d7f13148dc99a84333c0ddc5cbcb16379ab9fb1"
+version = "0.8.0"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 1.4.1",
@@ -8929,12 +9382,11 @@ dependencies = [
  "ecies",
  "hex-literal",
  "itertools 0.14.0",
- "k256 0.13.4 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "openvm-ecc-guest 1.4.1",
+ "k256 0.13.4 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
+ "openvm-ecc-guest 1.6.0",
  "openvm-pairing",
  "openvm-sha2",
- "p256 0.13.2 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.1)",
- "rkyv",
+ "p256 0.13.2 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
  "sbv-core",
  "sbv-helpers",
  "sbv-primitives",
@@ -8946,15 +9398,15 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-verifier"
-version = "0.7.1"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.2#3d7f13148dc99a84333c0ddc5cbcb16379ab9fb1"
+version = "0.8.0"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=1839b4905bd920bf75de9c25997b8383029e021d#1839b4905bd920bf75de9c25997b8383029e021d"
 dependencies = [
  "bincode",
  "eyre",
  "once_cell",
- "openvm-continuations 1.4.1",
- "openvm-native-recursion 1.4.1",
- "openvm-sdk 1.4.1",
+ "openvm-continuations 1.6.0",
+ "openvm-native-recursion 1.6.0",
+ "openvm-sdk 1.6.0",
  "scroll-zkvm-types",
  "serde",
  "serde_json",
@@ -9323,12 +9775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9440,6 +9886,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -9718,7 +10173,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9892,21 +10347,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -10208,10 +10648,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tstr"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8e0294f14baae476d0dd0a2d780b2e24d66e349a9de876f5126777a37bdba7"
+dependencies = [
+ "tstr_proc_macros",
+]
+
+[[package]]
+name = "tstr_proc_macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "ucd-trie"
@@ -10319,16 +10786,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "valuable"
@@ -10593,15 +11050,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "abi_stable"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,17 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addchain"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
-dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,18 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8202ab55fcbf46ca829833f347a82a2a4ce0596f0304ac322c2d100030cd56"
 dependencies = [
  "crypto-common 0.2.0-rc.4",
- "inout 0.2.1",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures",
+ "inout",
 ]
 
 [[package]]
@@ -114,7 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
 dependencies = [
  "cfg-if",
- "cipher 0.5.0-rc.1",
+ "cipher",
  "cpufeatures",
 ]
 
@@ -125,8 +93,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be322be4a73a3a55ad74b9833238e76bfd6034ce69a05c1b41c879f6a3bdca6"
 dependencies = [
  "aead",
- "aes 0.9.0-rc.1",
- "cipher 0.5.0-rc.1",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
@@ -165,7 +133,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc32535569185cbcb6ad5fa64d989a47bccb9a08e27284b1f2a3ccf16e6d010"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "num_enum",
  "serde",
@@ -179,7 +147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6440213a22df93a87ed512d2f668e7dc1d62a05642d107f82d61edc9e12370"
 dependencies = [
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 1.1.2",
  "alloy-trie 0.9.1",
@@ -207,7 +175,7 @@ checksum = "15d0bea09287942405c4f9d2a4f22d1e07611c2dbd9d5bf94b75366340f9e6e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 1.1.2",
  "serde",
@@ -219,7 +187,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "crc",
  "serde",
@@ -232,7 +200,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "serde",
@@ -244,7 +212,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -262,7 +230,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.14.0",
  "auto_impl",
@@ -282,7 +250,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 1.1.2",
  "auto_impl",
@@ -305,8 +273,8 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
  "alloy-hardforks",
- "alloy-primitives 1.4.1",
- "alloy-sol-types 1.4.1",
+ "alloy-primitives",
+ "alloy-sol-types",
  "auto_impl",
  "derive_more 2.0.1",
  "revm 30.1.1",
@@ -320,7 +288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc47eaae86488b07ea8e20236184944072a78784a1f4993f8ec17b3aa5d08c21"
 dependencies = [
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-serde 1.1.2",
  "alloy-trie 0.9.1",
  "borsh",
@@ -336,21 +304,9 @@ checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "auto_impl",
  "dyn-clone",
-]
-
-[[package]]
-name = "alloy-json-abi"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4584e3641181ff073e9d5bec5b3b8f78f9749d9fb108a1cfbc4399a4a139c72a"
-dependencies = [
- "alloy-primitives 0.8.26",
- "alloy-sol-type-parser",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -361,69 +317,9 @@ checksum = "7805124ad69e57bbae7731c9c344571700b2a18d351bda9e0eba521c991d1bcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-serde 1.1.2",
  "serde",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
-dependencies = [
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 0.99.20",
- "hex-literal",
- "itoa",
- "ruint",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0628ec0ba5b98b3370bb6be17b12f23bfce8ee4ad83823325a20546d9b03b78"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 0.99.20",
- "hex-literal",
- "itoa",
- "ruint",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777d58b30eb9a4db0e5f59bc30e8c2caef877fee7dc8734cf242a51a60f22e05"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 2.0.1",
- "foldhash 0.1.5",
- "hashbrown 0.15.5",
- "indexmap 2.12.1",
- "itoa",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-asm",
- "paste",
- "proptest",
- "rand 0.8.5",
- "ruint",
- "rustc-hash 2.1.1",
- "serde",
- "sha3",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -481,7 +377,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b2ca3a434a6d49910a7e8e51797eb25db42ef8a5578c52d877fcb26d0afe7bc"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "derive_more 2.0.1",
  "serde",
  "serde_with",
@@ -495,7 +391,7 @@ checksum = "d9c4c53a8b0905d931e7921774a1830609713bd3e8222347963172b03a3ecc68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "derive_more 2.0.1",
  "strum 0.27.2",
@@ -511,10 +407,10 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-eips 1.1.2",
  "alloy-network-primitives",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 1.1.2",
- "alloy-sol-types 1.4.1",
+ "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
  "serde_json",
@@ -528,7 +424,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "serde",
  "serde_json",
 ]
@@ -539,23 +435,9 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6f180c399ca7c1e2fe17ea58343910cad0090878a696ff5a50241aee12fc529"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68b32b6fa0d09bb74b4cefe35ccc8269d711c26629bc7cd98a47eeb12fe353f"
-dependencies = [
- "alloy-sol-macro-expander 0.8.26",
- "alloy-sol-macro-input 0.8.26",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -564,31 +446,12 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ce480400051b5217f19d6e9a82d9010cdde20f1ae9c00d53591e4a1afbb312"
 dependencies = [
- "alloy-sol-macro-expander 1.4.1",
- "alloy-sol-macro-input 1.4.1",
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2afe6879ac373e58fd53581636f2cce843998ae0b058ebe1e4f649195e2bd23c"
-dependencies = [
- "alloy-json-abi",
- "alloy-sol-macro-input 0.8.26",
- "const-hex",
- "heck 0.5.0",
- "indexmap 2.12.1",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.110",
- "syn-solidity 0.8.26",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -597,7 +460,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d792e205ed3b72f795a8044c52877d2e6b6e9b1d13f431478121d8d4eaa9028"
 dependencies = [
- "alloy-sol-macro-input 1.4.1",
+ "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.12.1",
@@ -605,26 +468,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
- "syn-solidity 1.4.1",
+ "syn-solidity",
  "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ba01aee235a8c699d07e5be97ba215607564e71be72f433665329bec307d28"
-dependencies = [
- "alloy-json-abi",
- "const-hex",
- "dunce",
- "heck 0.5.0",
- "macro-string",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.110",
- "syn-solidity 0.8.26",
 ]
 
 [[package]]
@@ -640,30 +485,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
- "syn-solidity 1.4.1",
-]
-
-[[package]]
-name = "alloy-sol-type-parser"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c13fc168b97411e04465f03e632f31ef94cad1c7c8951bf799237fd7870d535"
-dependencies = [
- "serde",
- "winnow 0.7.13",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e960c4b52508ef2ae1e37cae5058e905e9ae099b107900067a503f8c454036f"
-dependencies = [
- "alloy-json-abi",
- "alloy-primitives 0.8.26",
- "alloy-sol-macro 0.8.26",
- "const-hex",
- "serde",
+ "syn-solidity",
 ]
 
 [[package]]
@@ -672,8 +494,8 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
 dependencies = [
- "alloy-primitives 1.4.1",
- "alloy-sol-macro 1.4.1",
+ "alloy-primitives",
+ "alloy-sol-macro",
 ]
 
 [[package]]
@@ -682,7 +504,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
@@ -698,7 +520,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3412d52bb97c6c6cc27ccc28d4e6e8cf605469101193b50b0bd5813b1f990b5"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
@@ -795,16 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "ariadne"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367fd0ad87307588d087544707bc5fbf4805ded96c7db922b70d368fa1cb5702"
-dependencies = [
- "unicode-width",
- "yansi 0.5.1",
-]
-
-[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,7 +655,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -860,7 +672,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -880,7 +692,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -901,7 +713,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "zeroize",
@@ -943,7 +755,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -955,7 +767,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -968,7 +780,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1001,7 +813,7 @@ dependencies = [
  "ark-relations",
  "ark-std 0.5.0",
  "educe",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "tracing",
@@ -1037,7 +849,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1050,7 +862,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1123,15 +935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,15 +943,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -1214,12 +1008,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1241,27 +1029,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1311,12 +1084,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -1360,7 +1127,7 @@ checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1373,7 +1140,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1493,22 +1260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,26 +1290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1646,23 +1377,13 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.6",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
 version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
  "block-buffer 0.11.0",
  "crypto-common 0.2.0-rc.4",
- "inout 0.2.1",
+ "inout",
 ]
 
 [[package]]
@@ -1718,7 +1439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1770,21 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -1849,15 +1558,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "critical-section"
@@ -1965,7 +1665,7 @@ version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27e41d01c6f73b9330177f5cf782ae5b581b5f2c7840e298e0275ceee5001434"
 dependencies = [
- "cipher 0.5.0-rc.1",
+ "cipher",
 ]
 
 [[package]]
@@ -2085,19 +1785,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -2132,7 +1819,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case 0.7.1",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
@@ -2158,48 +1845,6 @@ dependencies = [
  "const-oid",
  "crypto-common 0.1.6",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -2307,15 +1952,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,24 +2022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3",
- "thiserror 1.0.69",
- "uint",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2414,10 +2033,6 @@ checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
  "tiny-keccak",
 ]
 
@@ -2429,90 +2044,8 @@ checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
  "primitive-types",
- "scale-info",
  "uint",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
-dependencies = [
- "arrayvec",
- "bytes",
- "chrono",
- "const-hex",
- "elliptic-curve",
- "ethabi",
- "generic-array",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_enum",
- "open-fastrlp",
- "rand 0.8.5",
- "rlp",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "ethers-etherscan"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
-dependencies = [
- "chrono",
- "ethers-core",
- "reqwest 0.11.27",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "2.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de34e484e7ae3cab99fbfd013d6c5dc7f9013676a4e0e414d8b12e1213e8b3ba"
-dependencies = [
- "cfg-if",
- "const-hex",
- "dirs",
- "dunce",
- "ethers-core",
- "futures-util",
- "glob",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "solang-parser",
- "svm-rs",
- "svm-rs-builds",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tokio",
- "tracing",
- "walkdir",
- "yansi 0.5.1",
 ]
 
 [[package]]
@@ -2571,39 +2104,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "bitvec",
- "byteorder",
- "ff_derive",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
-dependencies = [
- "addchain",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "figment"
-version = "0.10.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
-dependencies = [
- "atomic",
- "pear",
- "serde",
- "toml 0.8.23",
- "uncased",
- "version_check",
 ]
 
 [[package]]
@@ -2622,22 +2124,6 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
-]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -2674,69 +2160,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "forge-fmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0b82597ff80bc12b3b001dfb968769c345e353650dd32d337f2c64d2167c88"
-dependencies = [
- "alloy-primitives 0.3.3",
- "ariadne",
- "foundry-config",
- "itertools 0.11.0",
- "solang-parser",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "foundry-config"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a64a9bdad47eb4d950523b8ff14e675db8f2226a2aef79063d9344449b3abd5"
-dependencies = [
- "Inflector",
- "dirs-next",
- "ethers-core",
- "ethers-etherscan",
- "ethers-solc",
- "eyre",
- "figment",
- "globset",
- "number_prefix",
- "once_cell",
- "open-fastrlp",
- "path-slash",
- "regex",
- "reqwest 0.11.27",
- "revm-primitives 1.3.0",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "serde_regex",
- "thiserror 1.0.69",
- "toml 0.7.8",
- "toml_edit 0.19.15",
- "tracing",
- "walkdir",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -2768,17 +2197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,7 +2216,6 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2806,12 +2223,6 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
-
-[[package]]
-name = "gcd"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generational-arena"
@@ -2896,19 +2307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "gmp-mpfr-sys"
 version = "1.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,25 +2343,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.12.1",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
@@ -2973,7 +2352,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http",
  "indexmap 2.12.1",
  "slab",
  "tokio",
@@ -3022,7 +2401,7 @@ dependencies = [
  "halo2-axiom",
  "itertools 0.11.0",
  "log",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "poseidon-primitives",
@@ -3041,7 +2420,7 @@ checksum = "645c00681fdd1febaf552d8814e9f5a6a142d81a1514102190da07039588b366"
 dependencies = [
  "halo2-base",
  "itertools 0.11.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "rand 0.8.5",
@@ -3068,35 +2447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "halo2curves"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b756596082144af6e57105a20403b7b80fe9dccd085700b74fae3af523b74dba"
-dependencies = [
- "blake2",
- "digest 0.10.7",
- "ff 0.13.1",
- "group 0.13.0",
- "halo2derive",
- "hex",
- "lazy_static",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "pairing 0.23.0",
- "paste",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rayon",
- "serde",
- "serde_arrays",
- "sha2 0.10.9",
- "static_assertions",
- "subtle",
- "unroll",
-]
-
-[[package]]
 name = "halo2curves-axiom"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,7 +2458,7 @@ dependencies = [
  "group 0.13.0",
  "hex",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "pairing 0.23.0",
  "pasta_curves 0.5.1",
@@ -3135,7 +2485,7 @@ dependencies = [
  "group 0.13.0",
  "hex",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "pairing 0.23.0",
  "pasta_curves 0.5.1",
@@ -3152,20 +2502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "halo2derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb99e7492b4f5ff469d238db464131b86c2eaac814a78715acba369f64d2c76"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,7 +2514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -3190,7 +2525,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -3265,26 +2599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,23 +2611,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -3324,8 +2627,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -3334,12 +2637,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
@@ -3352,30 +2649,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -3384,9 +2657,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -3398,31 +2671,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -3434,7 +2693,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3448,20 +2707,20 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
- "system-configuration 0.6.1",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -3610,24 +2869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,21 +2909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "inout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,16 +2922,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3813,13 +3029,13 @@ dependencies = [
  "elliptic-curve",
  "ff 0.13.1",
  "hex-literal",
- "num-bigint 0.4.6",
+ "num-bigint",
  "once_cell",
- "openvm 1.6.0",
- "openvm-algebra-guest 1.6.0",
- "openvm-algebra-moduli-macros 1.6.0",
- "openvm-ecc-guest 1.6.0",
- "openvm-ecc-sw-macros 1.6.0",
+ "openvm",
+ "openvm-algebra-guest",
+ "openvm-algebra-moduli-macros",
+ "openvm-ecc-guest",
+ "openvm-ecc-sw-macros",
  "serde",
 ]
 
@@ -3840,36 +3056,6 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -3904,23 +3090,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "libredox"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-dependencies = [
- "bitflags 2.10.0",
- "libc",
-]
-
-[[package]]
 name = "libsecp256k1"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64 0.22.1",
+ "base64",
  "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
@@ -4032,16 +3208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,7 +3287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -4174,12 +3339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4203,22 +3362,11 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -4275,7 +3423,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -4289,7 +3437,7 @@ dependencies = [
  "bitvec",
  "either",
  "lru",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-modular",
  "num-traits",
@@ -4302,7 +3450,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -4347,24 +3495,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "nums"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3c74f925fb8cfc49a8022f2afce48a0683b70f9e439885594e84c5edbf5b01"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -4427,7 +3557,7 @@ checksum = "3a501241474c3118833d6195312ae7eb7cc90bbb0d5f524cbb0b06619e49ff67"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 1.1.2",
  "derive_more 2.0.1",
@@ -4443,37 +3573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4513,59 +3618,17 @@ dependencies = [
 
 [[package]]
 name = "openvm"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "bytemuck",
- "num-bigint 0.4.6",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.0)",
- "openvm-platform 1.4.0",
- "openvm-rv32im-guest 1.4.0",
- "serde",
-]
-
-[[package]]
-name = "openvm"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.16",
  "getrandom 0.3.4",
- "num-bigint 0.4.6",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
- "openvm-platform 1.6.0",
- "openvm-rv32im-guest 1.6.0",
+ "num-bigint",
+ "openvm-custom-insn",
+ "openvm-platform",
+ "openvm-rv32im-guest",
  "serde",
-]
-
-[[package]]
-name = "openvm-algebra-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "eyre",
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.4.6",
- "num-traits",
- "openvm-algebra-transpiler 1.4.0",
- "openvm-circuit 1.4.0",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-circuit-primitives-derive 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-mod-circuit-builder 1.4.0",
- "openvm-rv32-adapters 1.4.0",
- "openvm-rv32im-circuit 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "rand 0.8.5",
- "serde",
- "serde_with",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -4579,19 +3642,19 @@ dependencies = [
  "derive_more 1.0.0",
  "eyre",
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
- "openvm-algebra-transpiler 1.6.0",
- "openvm-circuit 1.6.0",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-circuit-primitives-derive 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-mod-circuit-builder 1.6.0",
- "openvm-rv32-adapters 1.6.0",
- "openvm-rv32im-circuit 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
+ "openvm-algebra-transpiler",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-circuit-primitives-derive",
+ "openvm-instructions",
+ "openvm-mod-circuit-builder",
+ "openvm-rv32-adapters",
+ "openvm-rv32im-circuit",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
  "rand 0.9.2",
  "serde",
  "serde_with",
@@ -4600,38 +3663,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-complex-macros"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-macros-common 1.4.0",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-algebra-complex-macros"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-macros-common 1.6.0",
+ "openvm-macros-common",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-algebra-guest"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.4.6",
- "once_cell",
- "openvm-algebra-complex-macros 1.4.0",
- "openvm-algebra-moduli-macros 1.4.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.0)",
- "openvm-rv32im-guest 1.4.0",
- "serde-big-array",
- "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -4640,52 +3677,26 @@ version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
- "num-bigint 0.4.6",
+ "num-bigint",
  "once_cell",
- "openvm-algebra-complex-macros 1.6.0",
- "openvm-algebra-moduli-macros 1.6.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
- "openvm-rv32im-guest 1.6.0",
+ "openvm-algebra-complex-macros",
+ "openvm-algebra-moduli-macros",
+ "openvm-custom-insn",
+ "openvm-rv32im-guest",
  "serde-big-array",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "num-bigint 0.4.6",
- "num-prime",
- "openvm-macros-common 1.4.0",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-algebra-moduli-macros"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-prime",
- "openvm-macros-common 1.6.0",
+ "openvm-macros-common",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-algebra-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-algebra-guest 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-instructions-derive 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-transpiler 1.4.0",
- "rrs-lib",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -4693,36 +3704,13 @@ name = "openvm-algebra-transpiler"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-algebra-guest 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-instructions-derive 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-transpiler 1.6.0",
+ "openvm-algebra-guest",
+ "openvm-instructions",
+ "openvm-instructions-derive",
+ "openvm-stark-backend",
+ "openvm-transpiler",
  "rrs-lib",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-bigint-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "openvm-bigint-transpiler 1.4.0",
- "openvm-circuit 1.4.0",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-circuit-primitives-derive 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-rv32-adapters 1.4.0",
- "openvm-rv32im-circuit 1.4.0",
- "openvm-rv32im-transpiler 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "rand 0.8.5",
- "serde",
 ]
 
 [[package]]
@@ -4733,52 +3721,28 @@ dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "openvm-bigint-transpiler 1.6.0",
- "openvm-circuit 1.6.0",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-circuit-primitives-derive 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-rv32-adapters 1.6.0",
- "openvm-rv32im-circuit 1.6.0",
- "openvm-rv32im-transpiler 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
+ "openvm-bigint-transpiler",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-circuit-primitives-derive",
+ "openvm-instructions",
+ "openvm-rv32-adapters",
+ "openvm-rv32im-circuit",
+ "openvm-rv32im-transpiler",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
  "rand 0.9.2",
  "serde",
 ]
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-platform 1.4.0",
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "openvm-bigint-guest"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-platform 1.6.0",
+ "openvm-platform",
  "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "openvm-bigint-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-bigint-guest 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-instructions-derive 1.4.0",
- "openvm-rv32im-transpiler 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-transpiler 1.4.0",
- "rrs-lib",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -4786,26 +3750,14 @@ name = "openvm-bigint-transpiler"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-bigint-guest 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-instructions-derive 1.6.0",
- "openvm-rv32im-transpiler 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-transpiler 1.6.0",
+ "openvm-bigint-guest",
+ "openvm-instructions",
+ "openvm-instructions-derive",
+ "openvm-rv32im-transpiler",
+ "openvm-stark-backend",
+ "openvm-transpiler",
  "rrs-lib",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-build"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cargo_metadata",
- "eyre",
- "openvm-platform 1.4.0",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4815,44 +3767,9 @@ source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0
 dependencies = [
  "cargo_metadata",
  "eyre",
- "openvm-platform 1.6.0",
+ "openvm-platform",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "openvm-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "backtrace",
- "cfg-if",
- "dashmap",
- "derivative",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "enum_dispatch",
- "eyre",
- "getset",
- "itertools 0.14.0",
- "libc",
- "memmap2",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-circuit-primitives-derive 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-poseidon2-air 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "p3-baby-bear 0.1.0",
- "p3-field 0.1.0",
- "rand 0.8.5",
- "rustc-hash 2.1.1",
- "serde",
- "serde-big-array",
- "static_assertions",
- "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
@@ -4873,15 +3790,15 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "memmap2",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-circuit-primitives-derive 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-poseidon2-air 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
- "p3-baby-bear 0.4.3",
- "p3-field 0.4.3",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-circuit-primitives-derive",
+ "openvm-instructions",
+ "openvm-poseidon2-air",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "p3-baby-bear",
+ "p3-field",
  "rand 0.9.2",
  "rustc-hash 2.1.1",
  "serde",
@@ -4893,17 +3810,6 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-circuit-derive"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
@@ -4915,48 +3821,22 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "derive-new 0.6.0",
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "num-traits",
- "openvm-circuit-primitives-derive 1.4.0",
- "openvm-cuda-builder 1.2.0",
- "openvm-stark-backend 1.2.0",
- "rand 0.8.5",
- "tracing",
-]
-
-[[package]]
-name = "openvm-circuit-primitives"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
- "openvm-circuit-primitives-derive 1.6.0",
- "openvm-cuda-builder 1.4.0",
- "openvm-stark-backend 1.4.0",
+ "openvm-circuit-primitives-derive",
+ "openvm-cuda-builder",
+ "openvm-stark-backend",
  "rand 0.9.2",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "itertools 0.14.0",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-circuit-primitives-derive"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
@@ -4967,42 +3847,18 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "derivative",
- "openvm-circuit 1.4.0",
- "openvm-native-compiler 1.4.0",
- "openvm-native-recursion 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "serde",
- "static_assertions",
-]
-
-[[package]]
-name = "openvm-continuations"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derivative",
- "openvm-circuit 1.6.0",
- "openvm-native-compiler 1.6.0",
- "openvm-native-recursion 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
+ "openvm-circuit",
+ "openvm-native-compiler",
+ "openvm-native-recursion",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
  "p3-bn254",
  "serde",
  "static_assertions",
-]
-
-[[package]]
-name = "openvm-cuda-builder"
-version = "1.2.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
-dependencies = [
- "cc",
- "glob",
 ]
 
 [[package]]
@@ -5017,50 +3873,11 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-custom-insn"
-version = "0.1.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-ecc-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-literal",
- "lazy_static",
- "num-bigint 0.4.6",
- "num-traits",
- "once_cell",
- "openvm-algebra-circuit 1.4.0",
- "openvm-circuit 1.4.0",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-ecc-transpiler 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-mod-circuit-builder 1.4.0",
- "openvm-rv32-adapters 1.4.0",
- "openvm-stark-backend 1.2.0",
- "rand 0.8.5",
- "serde",
- "serde_with",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -5075,41 +3892,22 @@ dependencies = [
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "hex-literal",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "once_cell",
- "openvm-algebra-circuit 1.6.0",
- "openvm-circuit 1.6.0",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-ecc-transpiler 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-mod-circuit-builder 1.6.0",
- "openvm-rv32-adapters 1.6.0",
- "openvm-stark-backend 1.4.0",
+ "openvm-algebra-circuit",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-ecc-transpiler",
+ "openvm-instructions",
+ "openvm-mod-circuit-builder",
+ "openvm-rv32-adapters",
+ "openvm-stark-backend",
  "rand 0.9.2",
  "serde",
  "serde_with",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-ecc-guest"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "group 0.13.0",
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell",
- "openvm 1.4.0",
- "openvm-algebra-guest 1.4.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.0)",
- "openvm-ecc-sw-macros 1.4.0",
- "openvm-rv32im-guest 1.4.0",
- "serde",
- "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -5122,23 +3920,13 @@ dependencies = [
  "group 0.13.0",
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "once_cell",
- "openvm 1.6.0",
- "openvm-algebra-guest 1.6.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
- "openvm-ecc-sw-macros 1.6.0",
- "openvm-rv32im-guest 1.6.0",
+ "openvm",
+ "openvm-algebra-guest",
+ "openvm-custom-insn",
+ "openvm-ecc-sw-macros",
+ "openvm-rv32im-guest",
  "serde",
  "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "openvm-ecc-sw-macros"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-macros-common 1.4.0",
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -5146,23 +3934,9 @@ name = "openvm-ecc-sw-macros"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-macros-common 1.6.0",
+ "openvm-macros-common",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "openvm-ecc-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-ecc-guest 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-instructions-derive 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-transpiler 1.4.0",
- "rrs-lib",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -5170,30 +3944,13 @@ name = "openvm-ecc-transpiler"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-ecc-guest 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-instructions-derive 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-transpiler 1.6.0",
+ "openvm-ecc-guest",
+ "openvm-instructions",
+ "openvm-instructions-derive",
+ "openvm-stark-backend",
+ "openvm-transpiler",
  "rrs-lib",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-instructions"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "backtrace",
- "derive-new 0.6.0",
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "num-traits",
- "openvm-instructions-derive 1.4.0",
- "openvm-stark-backend 1.2.0",
- "serde",
- "strum 0.26.3",
- "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -5204,22 +3961,13 @@ dependencies = [
  "backtrace",
  "derive-new 0.6.0",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
- "openvm-instructions-derive 1.6.0",
- "openvm-stark-backend 1.4.0",
+ "openvm-instructions-derive",
+ "openvm-stark-backend",
  "serde",
  "strum 0.26.3",
  "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "openvm-instructions-derive"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -5233,31 +3981,6 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "itertools 0.14.0",
- "openvm-circuit 1.4.0",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-circuit-primitives-derive 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-keccak256-transpiler 1.4.0",
- "openvm-rv32im-circuit 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "p3-keccak-air 0.1.0",
- "rand 0.8.5",
- "serde",
- "strum 0.26.3",
- "tiny-keccak",
-]
-
-[[package]]
-name = "openvm-keccak256-circuit"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
@@ -5265,16 +3988,16 @@ dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "itertools 0.14.0",
- "openvm-circuit 1.6.0",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-circuit-primitives-derive 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-keccak256-transpiler 1.6.0",
- "openvm-rv32im-circuit 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
- "p3-keccak-air 0.4.3",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-circuit-primitives-derive",
+ "openvm-instructions",
+ "openvm-keccak256-transpiler",
+ "openvm-rv32im-circuit",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "p3-keccak-air",
  "rand 0.9.2",
  "serde",
  "strum 0.26.3",
@@ -5283,32 +4006,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-platform 1.4.0",
-]
-
-[[package]]
-name = "openvm-keccak256-guest"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-platform 1.6.0",
-]
-
-[[package]]
-name = "openvm-keccak256-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-instructions 1.4.0",
- "openvm-instructions-derive 1.4.0",
- "openvm-keccak256-guest 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-transpiler 1.4.0",
- "rrs-lib",
- "strum 0.26.3",
+ "openvm-platform",
 ]
 
 [[package]]
@@ -5316,21 +4017,13 @@ name = "openvm-keccak256-transpiler"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.6.0",
- "openvm-instructions-derive 1.6.0",
- "openvm-keccak256-guest 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-transpiler 1.6.0",
+ "openvm-instructions",
+ "openvm-instructions-derive",
+ "openvm-keccak256-guest",
+ "openvm-stark-backend",
+ "openvm-transpiler",
  "rrs-lib",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-macros-common"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -5343,67 +4036,21 @@ dependencies = [
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "num-traits",
- "openvm-circuit 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-cuda-builder 1.2.0",
- "openvm-instructions 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "rand 0.8.5",
- "tracing",
-]
-
-[[package]]
-name = "openvm-mod-circuit-builder"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
- "openvm-circuit 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-cuda-builder 1.4.0",
- "openvm-instructions 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
+ "openvm-circuit",
+ "openvm-circuit-primitives",
+ "openvm-cuda-builder",
+ "openvm-instructions",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
  "rand 0.8.5",
  "rand 0.9.2",
  "tracing",
-]
-
-[[package]]
-name = "openvm-native-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "eyre",
- "itertools 0.14.0",
- "openvm-circuit 1.4.0",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-circuit-primitives-derive 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-native-compiler 1.4.0",
- "openvm-poseidon2-air 1.4.0",
- "openvm-rv32im-circuit 1.4.0",
- "openvm-rv32im-transpiler 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "p3-field 0.1.0",
- "rand 0.8.5",
- "serde",
- "static_assertions",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -5416,45 +4063,22 @@ dependencies = [
  "derive_more 1.0.0",
  "eyre",
  "itertools 0.14.0",
- "openvm-circuit 1.6.0",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-circuit-primitives-derive 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-native-compiler 1.6.0",
- "openvm-poseidon2-air 1.6.0",
- "openvm-rv32im-circuit 1.6.0",
- "openvm-rv32im-transpiler 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
- "p3-field 0.4.3",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-circuit-primitives-derive",
+ "openvm-instructions",
+ "openvm-native-compiler",
+ "openvm-poseidon2-air",
+ "openvm-rv32im-circuit",
+ "openvm-rv32im-transpiler",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "p3-field",
  "rand 0.9.2",
  "serde",
  "static_assertions",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-native-compiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "backtrace",
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "num-integer",
- "openvm-circuit 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-instructions-derive 1.4.0",
- "openvm-native-compiler-derive 1.4.0",
- "openvm-rv32im-transpiler 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "serde",
- "snark-verifier-sdk",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "zkhash",
 ]
 
 [[package]]
@@ -5464,29 +4088,20 @@ source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
- "openvm-circuit 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-instructions-derive 1.6.0",
- "openvm-native-compiler-derive 1.6.0",
- "openvm-rv32im-transpiler 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
+ "openvm-circuit",
+ "openvm-instructions",
+ "openvm-instructions-derive",
+ "openvm-native-compiler-derive",
+ "openvm-rv32im-transpiler",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
  "serde",
  "snark-verifier-sdk",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "zkhash",
-]
-
-[[package]]
-name = "openvm-native-compiler-derive"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -5500,33 +4115,6 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "itertools 0.14.0",
- "lazy_static",
- "once_cell",
- "openvm-circuit 1.4.0",
- "openvm-native-circuit 1.4.0",
- "openvm-native-compiler 1.4.0",
- "openvm-native-compiler-derive 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "p3-dft 0.1.0",
- "p3-fri 0.1.0",
- "p3-merkle-tree 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_with",
- "snark-verifier-sdk",
- "tracing",
-]
-
-[[package]]
-name = "openvm-native-recursion"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
@@ -5534,16 +4122,16 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "once_cell",
- "openvm-circuit 1.6.0",
- "openvm-native-circuit 1.6.0",
- "openvm-native-compiler 1.6.0",
- "openvm-native-compiler-derive 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
- "p3-dft 0.4.3",
- "p3-fri 0.4.3",
- "p3-merkle-tree 0.4.3",
- "p3-symmetric 0.4.3",
+ "openvm-circuit",
+ "openvm-native-circuit",
+ "openvm-native-compiler",
+ "openvm-native-compiler-derive",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "p3-dft",
+ "p3-fri",
+ "p3-merkle-tree",
+ "p3-symmetric",
  "rand 0.8.5",
  "rand 0.9.2",
  "serde",
@@ -5555,22 +4143,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-instructions 1.4.0",
- "openvm-transpiler 1.4.0",
- "p3-field 0.1.0",
-]
-
-[[package]]
-name = "openvm-native-transpiler"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.6.0",
- "openvm-transpiler 1.6.0",
- "p3-field 0.4.3",
+ "openvm-instructions",
+ "openvm-transpiler",
+ "p3-field",
 ]
 
 [[package]]
@@ -5582,48 +4160,19 @@ dependencies = [
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
  "hex-literal",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
- "openvm 1.6.0",
- "openvm-algebra-complex-macros 1.6.0",
- "openvm-algebra-guest 1.6.0",
- "openvm-algebra-moduli-macros 1.6.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
- "openvm-ecc-guest 1.6.0",
- "openvm-ecc-sw-macros 1.6.0",
- "openvm-pairing-guest 1.6.0",
- "openvm-platform 1.6.0",
- "openvm-rv32im-guest 1.6.0",
+ "openvm",
+ "openvm-algebra-complex-macros",
+ "openvm-algebra-guest",
+ "openvm-algebra-moduli-macros",
+ "openvm-custom-insn",
+ "openvm-ecc-guest",
+ "openvm-ecc-sw-macros",
+ "openvm-pairing-guest",
+ "openvm-platform",
+ "openvm-rv32im-guest",
  "serde",
-]
-
-[[package]]
-name = "openvm-pairing-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "eyre",
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.4.6",
- "num-traits",
- "openvm-algebra-circuit 1.4.0",
- "openvm-circuit 1.4.0",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-ecc-circuit 1.4.0",
- "openvm-ecc-guest 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-mod-circuit-builder 1.4.0",
- "openvm-pairing-guest 1.4.0",
- "openvm-pairing-transpiler 1.4.0",
- "openvm-rv32im-circuit 1.4.0",
- "openvm-stark-backend 1.2.0",
- "rand 0.8.5",
- "serde",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -5636,44 +4185,23 @@ dependencies = [
  "derive_more 1.0.0",
  "eyre",
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
- "openvm-algebra-circuit 1.6.0",
- "openvm-circuit 1.6.0",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-ecc-circuit 1.6.0",
- "openvm-ecc-guest 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-mod-circuit-builder 1.6.0",
- "openvm-pairing-guest 1.6.0",
- "openvm-pairing-transpiler 1.6.0",
- "openvm-rv32im-circuit 1.6.0",
- "openvm-stark-backend 1.4.0",
+ "openvm-algebra-circuit",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-ecc-circuit",
+ "openvm-ecc-guest",
+ "openvm-instructions",
+ "openvm-mod-circuit-builder",
+ "openvm-pairing-guest",
+ "openvm-pairing-transpiler",
+ "openvm-rv32im-circuit",
+ "openvm-stark-backend",
  "rand 0.9.2",
  "serde",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-pairing-guest"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-literal",
- "itertools 0.14.0",
- "lazy_static",
- "num-bigint 0.4.6",
- "num-traits",
- "openvm 1.4.0",
- "openvm-algebra-guest 1.4.0",
- "openvm-algebra-moduli-macros 1.4.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.0)",
- "openvm-ecc-guest 1.4.0",
- "rand 0.8.5",
- "serde",
- "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -5686,51 +4214,28 @@ dependencies = [
  "hex-literal",
  "itertools 0.14.0",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
- "openvm 1.6.0",
- "openvm-algebra-guest 1.6.0",
- "openvm-algebra-moduli-macros 1.6.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
- "openvm-ecc-guest 1.6.0",
+ "openvm",
+ "openvm-algebra-guest",
+ "openvm-algebra-moduli-macros",
+ "openvm-custom-insn",
+ "openvm-ecc-guest",
  "serde",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-instructions 1.4.0",
- "openvm-pairing-guest 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-transpiler 1.4.0",
- "rrs-lib",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-pairing-transpiler"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.6.0",
- "openvm-pairing-guest 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-transpiler 1.6.0",
+ "openvm-instructions",
+ "openvm-pairing-guest",
+ "openvm-stark-backend",
+ "openvm-transpiler",
  "rrs-lib",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-platform"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "libm",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.0)",
- "openvm-rv32im-guest 1.4.0",
 ]
 
 [[package]]
@@ -5739,26 +4244,8 @@ version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "libm",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
- "openvm-rv32im-guest 1.6.0",
-]
-
-[[package]]
-name = "openvm-poseidon2-air"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "derivative",
- "lazy_static",
- "openvm-cuda-builder 1.2.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "p3-monty-31 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-poseidon2-air 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
- "zkhash",
+ "openvm-custom-insn",
+ "openvm-rv32im-guest",
 ]
 
 [[package]]
@@ -5768,31 +4255,14 @@ source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0
 dependencies = [
  "derivative",
  "lazy_static",
- "openvm-cuda-builder 1.4.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
- "p3-poseidon2 0.4.3",
- "p3-poseidon2-air 0.4.3",
- "p3-symmetric 0.4.3",
+ "openvm-cuda-builder",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "p3-poseidon2",
+ "p3-poseidon2-air",
+ "p3-symmetric",
  "rand 0.9.2",
  "zkhash",
-]
-
-[[package]]
-name = "openvm-rv32-adapters"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "derive-new 0.6.0",
- "itertools 0.14.0",
- "openvm-circuit 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-circuit-primitives-derive 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-rv32im-circuit 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -5802,37 +4272,14 @@ source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
- "openvm-circuit 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-circuit-primitives-derive 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-rv32im-circuit 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
+ "openvm-circuit",
+ "openvm-circuit-primitives",
+ "openvm-circuit-primitives-derive",
+ "openvm-instructions",
+ "openvm-rv32im-circuit",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
  "rand 0.9.2",
-]
-
-[[package]]
-name = "openvm-rv32im-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "eyre",
- "num-bigint 0.4.6",
- "num-integer",
- "openvm-circuit 1.4.0",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-circuit-primitives-derive 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-rv32im-transpiler 1.4.0",
- "openvm-stark-backend 1.2.0",
- "rand 0.8.5",
- "serde",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -5844,15 +4291,15 @@ dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
- "openvm-circuit 1.6.0",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-circuit-primitives-derive 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-rv32im-transpiler 1.6.0",
- "openvm-stark-backend 1.4.0",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-circuit-primitives-derive",
+ "openvm-instructions",
+ "openvm-rv32im-transpiler",
+ "openvm-stark-backend",
  "rand 0.9.2",
  "serde",
  "strum 0.26.3",
@@ -5860,38 +4307,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.4.0)",
- "p3-field 0.1.0",
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "openvm-rv32im-guest"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
- "p3-field 0.4.3",
+ "openvm-custom-insn",
+ "p3-field",
  "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "openvm-rv32im-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-instructions 1.4.0",
- "openvm-instructions-derive 1.4.0",
- "openvm-rv32im-guest 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-transpiler 1.4.0",
- "rrs-lib",
- "serde",
- "strum 0.26.3",
- "tracing",
 ]
 
 [[package]]
@@ -5899,72 +4320,14 @@ name = "openvm-rv32im-transpiler"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.6.0",
- "openvm-instructions-derive 1.6.0",
- "openvm-rv32im-guest 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-transpiler 1.6.0",
+ "openvm-instructions",
+ "openvm-instructions-derive",
+ "openvm-rv32im-guest",
+ "openvm-stark-backend",
+ "openvm-transpiler",
  "rrs-lib",
  "serde",
  "strum 0.26.3",
- "tracing",
-]
-
-[[package]]
-name = "openvm-sdk"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "alloy-sol-types 0.8.26",
- "bitcode",
- "bon",
- "cfg-if",
- "clap",
- "derivative",
- "derive_more 1.0.0",
- "eyre",
- "forge-fmt",
- "getset",
- "hex",
- "itertools 0.14.0",
- "metrics",
- "num-bigint 0.4.6",
- "openvm 1.4.0",
- "openvm-algebra-circuit 1.4.0",
- "openvm-algebra-transpiler 1.4.0",
- "openvm-bigint-circuit 1.4.0",
- "openvm-bigint-transpiler 1.4.0",
- "openvm-build 1.4.0",
- "openvm-circuit 1.4.0",
- "openvm-continuations 1.4.0",
- "openvm-ecc-circuit 1.4.0",
- "openvm-ecc-transpiler 1.4.0",
- "openvm-keccak256-circuit 1.4.0",
- "openvm-keccak256-transpiler 1.4.0",
- "openvm-native-circuit 1.4.0",
- "openvm-native-compiler 1.4.0",
- "openvm-native-recursion 1.4.0",
- "openvm-native-transpiler 1.4.0",
- "openvm-pairing-circuit 1.4.0",
- "openvm-pairing-transpiler 1.4.0",
- "openvm-rv32im-circuit 1.4.0",
- "openvm-rv32im-transpiler 1.4.0",
- "openvm-sha256-circuit 1.4.0",
- "openvm-sha256-transpiler 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "openvm-transpiler 1.4.0",
- "p3-fri 0.1.0",
- "rand 0.8.5",
- "rrs-lib",
- "serde",
- "serde_json",
- "serde_with",
- "snark-verifier",
- "snark-verifier-sdk",
- "tempfile",
- "thiserror 1.0.69",
- "toml 0.8.23",
  "tracing",
 ]
 
@@ -5984,34 +4347,34 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "metrics",
- "num-bigint 0.4.6",
- "openvm 1.6.0",
- "openvm-algebra-circuit 1.6.0",
- "openvm-algebra-transpiler 1.6.0",
- "openvm-bigint-circuit 1.6.0",
- "openvm-bigint-transpiler 1.6.0",
- "openvm-build 1.6.0",
- "openvm-circuit 1.6.0",
- "openvm-continuations 1.6.0",
- "openvm-ecc-circuit 1.6.0",
- "openvm-ecc-transpiler 1.6.0",
- "openvm-keccak256-circuit 1.6.0",
- "openvm-keccak256-transpiler 1.6.0",
- "openvm-native-circuit 1.6.0",
- "openvm-native-compiler 1.6.0",
- "openvm-native-recursion 1.6.0",
- "openvm-native-transpiler 1.6.0",
- "openvm-pairing-circuit 1.6.0",
- "openvm-pairing-transpiler 1.6.0",
- "openvm-rv32im-circuit 1.6.0",
- "openvm-rv32im-transpiler 1.6.0",
- "openvm-sha256-circuit 1.6.0",
- "openvm-sha256-transpiler 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
- "openvm-transpiler 1.6.0",
+ "num-bigint",
+ "openvm",
+ "openvm-algebra-circuit",
+ "openvm-algebra-transpiler",
+ "openvm-bigint-circuit",
+ "openvm-bigint-transpiler",
+ "openvm-build",
+ "openvm-circuit",
+ "openvm-continuations",
+ "openvm-ecc-circuit",
+ "openvm-ecc-transpiler",
+ "openvm-keccak256-circuit",
+ "openvm-keccak256-transpiler",
+ "openvm-native-circuit",
+ "openvm-native-compiler",
+ "openvm-native-recursion",
+ "openvm-native-transpiler",
+ "openvm-pairing-circuit",
+ "openvm-pairing-transpiler",
+ "openvm-rv32im-circuit",
+ "openvm-rv32im-transpiler",
+ "openvm-sha256-circuit",
+ "openvm-sha256-transpiler",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "openvm-transpiler",
  "p3-bn254",
- "p3-fri 0.4.3",
+ "p3-fri",
  "rand 0.9.2",
  "rrs-lib",
  "serde",
@@ -6021,7 +4384,7 @@ dependencies = [
  "snark-verifier-sdk",
  "tempfile",
  "thiserror 1.0.69",
- "toml 0.8.23",
+ "toml",
  "tracing",
 ]
 
@@ -6030,18 +4393,7 @@ name = "openvm-sha2"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-sha256-guest 1.6.0",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "openvm-sha256-air"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-circuit-primitives 1.4.0",
- "openvm-stark-backend 1.2.0",
- "rand 0.8.5",
+ "openvm-sha256-guest",
  "sha2 0.10.9",
 ]
 
@@ -6050,33 +4402,10 @@ name = "openvm-sha256-air"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-circuit-primitives 1.6.0",
- "openvm-stark-backend 1.4.0",
+ "openvm-circuit-primitives",
+ "openvm-stark-backend",
  "rand 0.9.2",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "openvm-sha256-circuit"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "cfg-if",
- "derive-new 0.6.0",
- "derive_more 1.0.0",
- "openvm-circuit 1.4.0",
- "openvm-circuit-derive 1.4.0",
- "openvm-circuit-primitives 1.4.0",
- "openvm-instructions 1.4.0",
- "openvm-rv32im-circuit 1.4.0",
- "openvm-sha256-air 1.4.0",
- "openvm-sha256-transpiler 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-stark-sdk 1.2.0",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.9",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -6087,15 +4416,15 @@ dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "openvm-circuit 1.6.0",
- "openvm-circuit-derive 1.6.0",
- "openvm-circuit-primitives 1.6.0",
- "openvm-instructions 1.6.0",
- "openvm-rv32im-circuit 1.6.0",
- "openvm-sha256-air 1.6.0",
- "openvm-sha256-transpiler 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-stark-sdk 1.4.0",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-instructions",
+ "openvm-rv32im-circuit",
+ "openvm-sha256-air",
+ "openvm-sha256-transpiler",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
  "rand 0.9.2",
  "serde",
  "sha2 0.10.9",
@@ -6104,32 +4433,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-platform 1.4.0",
-]
-
-[[package]]
-name = "openvm-sha256-guest"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-platform 1.6.0",
-]
-
-[[package]]
-name = "openvm-sha256-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "openvm-instructions 1.4.0",
- "openvm-instructions-derive 1.4.0",
- "openvm-sha256-guest 1.4.0",
- "openvm-stark-backend 1.2.0",
- "openvm-transpiler 1.4.0",
- "rrs-lib",
- "strum 0.26.3",
+ "openvm-platform",
 ]
 
 [[package]]
@@ -6137,65 +4444,13 @@ name = "openvm-sha256-transpiler"
 version = "1.6.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "openvm-instructions 1.6.0",
- "openvm-instructions-derive 1.6.0",
- "openvm-sha256-guest 1.6.0",
- "openvm-stark-backend 1.4.0",
- "openvm-transpiler 1.6.0",
+ "openvm-instructions",
+ "openvm-instructions-derive",
+ "openvm-sha256-guest",
+ "openvm-stark-backend",
+ "openvm-transpiler",
  "rrs-lib",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "openvm-stark-backend"
-version = "1.2.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
-dependencies = [
- "bitcode",
- "cfg-if",
- "derivative",
- "derive-new 0.7.0",
- "itertools 0.14.0",
- "p3-air 0.1.0",
- "p3-challenger 0.1.0",
- "p3-commit 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-uni-stark",
- "p3-util 0.1.0",
- "rayon",
- "rustc-hash 2.1.1",
- "serde",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "openvm-stark-backend"
-version = "1.2.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.1#dde6cdaf105cc57d1609fd49568c7bce0a066cc2"
-dependencies = [
- "bitcode",
- "cfg-if",
- "derivative",
- "derive-new 0.7.0",
- "eyre",
- "itertools 0.14.0",
- "p3-air 0.1.0",
- "p3-challenger 0.1.0",
- "p3-commit 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-uni-stark",
- "p3-util 0.1.0",
- "rayon",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
@@ -6209,93 +4464,19 @@ dependencies = [
  "derive-new 0.7.0",
  "eyre",
  "itertools 0.14.0",
- "p3-air 0.4.3",
- "p3-challenger 0.4.3",
- "p3-commit 0.4.3",
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-util 0.4.3",
+ "p3-air",
+ "p3-challenger",
+ "p3-commit",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "rayon",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tracing",
-]
-
-[[package]]
-name = "openvm-stark-sdk"
-version = "1.2.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
-dependencies = [
- "dashmap",
- "derivative",
- "derive_more 0.99.20",
- "ff 0.13.1",
- "itertools 0.14.0",
- "metrics",
- "metrics-tracing-context",
- "metrics-util",
- "openvm-stark-backend 1.2.0",
- "p3-baby-bear 0.1.0",
- "p3-blake3 0.1.0",
- "p3-bn254-fr",
- "p3-dft 0.1.0",
- "p3-fri 0.1.0",
- "p3-goldilocks 0.1.0",
- "p3-keccak 0.1.0",
- "p3-koala-bear 0.1.0",
- "p3-merkle-tree 0.1.0",
- "p3-poseidon 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "static_assertions",
- "toml 0.8.23",
- "tracing",
- "tracing-forest",
- "tracing-subscriber 0.3.20",
- "zkhash",
-]
-
-[[package]]
-name = "openvm-stark-sdk"
-version = "1.2.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.1#dde6cdaf105cc57d1609fd49568c7bce0a066cc2"
-dependencies = [
- "dashmap",
- "derivative",
- "derive_more 1.0.0",
- "ff 0.13.1",
- "itertools 0.14.0",
- "metrics",
- "metrics-tracing-context",
- "metrics-util",
- "openvm-stark-backend 1.2.1",
- "p3-baby-bear 0.1.0",
- "p3-blake3 0.1.0",
- "p3-bn254-fr",
- "p3-dft 0.1.0",
- "p3-fri 0.1.0",
- "p3-goldilocks 0.1.0",
- "p3-keccak 0.1.0",
- "p3-koala-bear 0.1.0",
- "p3-merkle-tree 0.1.0",
- "p3-poseidon 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "static_assertions",
- "toml 0.8.23",
- "tracing",
- "tracing-forest",
- "tracing-subscriber 0.3.20",
- "zkhash",
 ]
 
 [[package]]
@@ -6311,43 +4492,29 @@ dependencies = [
  "metrics",
  "metrics-tracing-context",
  "metrics-util",
- "num-bigint 0.4.6",
- "openvm-stark-backend 1.4.0",
- "p3-baby-bear 0.4.3",
- "p3-blake3 0.4.3",
+ "num-bigint",
+ "openvm-stark-backend",
+ "p3-baby-bear",
+ "p3-blake3",
  "p3-bn254",
- "p3-dft 0.4.3",
- "p3-fri 0.4.3",
- "p3-goldilocks 0.4.3",
- "p3-keccak 0.4.3",
- "p3-koala-bear 0.4.3",
- "p3-merkle-tree 0.4.3",
- "p3-poseidon 0.4.3",
- "p3-poseidon2 0.4.3",
- "p3-symmetric 0.4.3",
+ "p3-dft",
+ "p3-fri",
+ "p3-goldilocks",
+ "p3-keccak",
+ "p3-koala-bear",
+ "p3-merkle-tree",
+ "p3-poseidon",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.9.2",
  "serde",
  "serde_json",
  "static_assertions",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.20",
  "zkhash",
-]
-
-[[package]]
-name = "openvm-transpiler"
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-dependencies = [
- "elf",
- "eyre",
- "openvm-instructions 1.4.0",
- "openvm-platform 1.4.0",
- "openvm-stark-backend 1.2.0",
- "rrs-lib",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6357,18 +4524,12 @@ source = "git+https://github.com/openvm-org/openvm.git?tag=v1.6.0#eda5bf031a6bd0
 dependencies = [
  "elf",
  "eyre",
- "openvm-instructions 1.6.0",
- "openvm-platform 1.6.0",
- "openvm-stark-backend 1.4.0",
+ "openvm-instructions",
+ "openvm-platform",
+ "openvm-stark-backend",
  "rrs-lib",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -6400,22 +4561,13 @@ dependencies = [
  "elliptic-curve",
  "ff 0.13.1",
  "hex-literal",
- "num-bigint 0.4.6",
- "openvm 1.6.0",
- "openvm-algebra-guest 1.6.0",
- "openvm-algebra-moduli-macros 1.6.0",
- "openvm-ecc-guest 1.6.0",
- "openvm-ecc-sw-macros 1.6.0",
+ "num-bigint",
+ "openvm",
+ "openvm-algebra-guest",
+ "openvm-algebra-moduli-macros",
+ "openvm-ecc-guest",
+ "openvm-ecc-sw-macros",
  "serde",
-]
-
-[[package]]
-name = "p3-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
 ]
 
 [[package]]
@@ -6424,22 +4576,8 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daee3082e2ca0db2ac876c43c9c8fd53204b0fcb95cfe7258d21f4a925ad82c4"
 dependencies = [
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
-]
-
-[[package]]
-name = "p3-baby-bear"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "p3-field 0.1.0",
- "p3-mds 0.1.0",
- "p3-monty-31 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
- "serde",
+ "p3-field",
+ "p3-matrix",
 ]
 
 [[package]]
@@ -6448,23 +4586,13 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a1a49f4d9c8b8cbdab61e25d9de1b78b3c8347dd2fb88b11d990b3efa8cdd3a"
 dependencies = [
- "p3-challenger 0.4.3",
- "p3-field 0.4.3",
- "p3-mds 0.4.3",
- "p3-monty-31 0.4.3",
- "p3-poseidon2 0.4.3",
- "p3-symmetric 0.4.3",
+ "p3-challenger",
+ "p3-field",
+ "p3-mds",
+ "p3-monty-31",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.9.2",
-]
-
-[[package]]
-name = "p3-blake3"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "blake3",
- "p3-symmetric 0.1.0",
- "p3-util 0.1.0",
 ]
 
 [[package]]
@@ -6474,8 +4602,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a8f97fd783752532861bf29bac344b7c226a0d1e2151148834c43c651a5d401"
 dependencies = [
  "blake3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "p3-symmetric",
+ "p3-util",
 ]
 
 [[package]]
@@ -6484,41 +4612,14 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "923bd91df7dd93481b4bfb53aa903d46d1a49d51160513472a5e95ca92ef1b46"
 dependencies = [
- "num-bigint 0.4.6",
- "p3-field 0.4.3",
- "p3-poseidon2 0.4.3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "num-bigint",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
  "paste",
  "rand 0.9.2",
  "serde",
-]
-
-[[package]]
-name = "p3-bn254-fr"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "ff 0.13.1",
- "halo2curves",
- "num-bigint 0.4.6",
- "p3-field 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "p3-challenger"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "p3-field 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-symmetric 0.1.0",
- "p3-util 0.1.0",
- "tracing",
 ]
 
 [[package]]
@@ -6527,26 +4628,12 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7d2d45f5a51dc3f965e8d6da60a6c26c807e88657863d56da275eaa05ad36f1"
 dependencies = [
- "p3-field 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-monty-31 0.4.3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-monty-31",
+ "p3-symmetric",
+ "p3-util",
  "tracing",
-]
-
-[[package]]
-name = "p3-commit"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-challenger 0.1.0",
- "p3-dft 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-util 0.1.0",
- "serde",
 ]
 
 [[package]]
@@ -6556,25 +4643,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6d7dcb58a8f21f0e1325dc7f7699ad749878ccbe7e286e61f9d46bde2bfa88"
 dependencies = [
  "itertools 0.14.0",
- "p3-challenger 0.4.3",
- "p3-dft 0.4.3",
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
- "p3-util 0.4.3",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
  "serde",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-util 0.1.0",
- "tracing",
 ]
 
 [[package]]
@@ -6584,28 +4658,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beabb40bc8ac7f5f95870f271fb844c7e2e1ebb7f0761a8eebb2614b56c6b1c1"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-util 0.4.3",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "spin 0.10.0",
- "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "nums",
- "p3-maybe-rayon 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
- "serde",
  "tracing",
 ]
 
@@ -6616,30 +4673,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4819a3e4c1882431a63d4847ffa10d110017aee4cb9cf4319ca6dca191930969"
 dependencies = [
  "itertools 0.14.0",
- "num-bigint 0.4.6",
- "p3-maybe-rayon 0.4.3",
- "p3-util 0.4.3",
+ "num-bigint",
+ "p3-maybe-rayon",
+ "p3-util",
  "paste",
  "rand 0.9.2",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-fri"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-challenger 0.1.0",
- "p3-commit 0.1.0",
- "p3-dft 0.1.0",
- "p3-field 0.1.0",
- "p3-interpolation 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
  "serde",
  "tracing",
 ]
@@ -6651,14 +4689,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13ca6a795cfc4180425fbf16dfdb4c9c2bfa85971dd55b5930d97b513e0835df"
 dependencies = [
  "itertools 0.14.0",
- "p3-challenger 0.4.3",
- "p3-commit 0.4.3",
- "p3-dft 0.4.3",
- "p3-field 0.4.3",
- "p3-interpolation 0.4.3",
- "p3-matrix 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-util 0.4.3",
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-interpolation",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.9.2",
  "serde",
  "thiserror 2.0.17",
@@ -6667,49 +4705,21 @@ dependencies = [
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "num-bigint 0.4.6",
- "p3-dft 0.1.0",
- "p3-field 0.1.0",
- "p3-mds 0.1.0",
- "p3-poseidon 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-symmetric 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "p3-goldilocks"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c47d5c650bbeb25941b9a1fa9bfaf59b3cd202a438ea2c20892489af001399"
 dependencies = [
- "num-bigint 0.4.6",
- "p3-challenger 0.4.3",
- "p3-dft 0.4.3",
- "p3-field 0.4.3",
- "p3-mds 0.4.3",
- "p3-poseidon2 0.4.3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "num-bigint",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
  "paste",
  "rand 0.9.2",
  "serde",
-]
-
-[[package]]
-name = "p3-interpolation"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-util 0.1.0",
 ]
 
 [[package]]
@@ -6718,22 +4728,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27a3696641a8f4ec990ff8c91862fb4f3b4ff29f589f78005d046023fe3550f"
 dependencies = [
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-util 0.4.3",
-]
-
-[[package]]
-name = "p3-keccak"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.1.0",
- "p3-symmetric 0.1.0",
- "p3-util 0.1.0",
- "tiny-keccak",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
 ]
 
 [[package]]
@@ -6742,24 +4740,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a61b090fb42152d1fcb2f82227b8619b1b022f9cd4a123123dccc9c2ab75d5de"
 dependencies = [
- "p3-field 0.4.3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "p3-field",
+ "p3-symmetric",
+ "p3-util",
  "tiny-keccak",
-]
-
-[[package]]
-name = "p3-keccak-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "p3-air 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
- "tracing",
 ]
 
 [[package]]
@@ -6768,27 +4752,13 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4832d817455f7a4a35b598cbb8a42f1ee0430ee82df0203956c26917b2509865"
 dependencies = [
- "p3-air 0.4.3",
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-util 0.4.3",
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.9.2",
  "tracing",
-]
-
-[[package]]
-name = "p3-koala-bear"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "p3-field 0.1.0",
- "p3-mds 0.1.0",
- "p3-monty-31 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
- "serde",
 ]
 
 [[package]]
@@ -6797,27 +4767,12 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb02789fca0950e246123d652bd78e75a76e3b90a651fd88dbb215cd3e81f5a"
 dependencies = [
- "p3-challenger 0.4.3",
- "p3-field 0.4.3",
- "p3-monty-31 0.4.3",
- "p3-poseidon2 0.4.3",
- "p3-symmetric 0.4.3",
+ "p3-challenger",
+ "p3-field",
+ "p3-monty-31",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.9.2",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
- "serde",
- "tracing",
- "transpose",
 ]
 
 [[package]]
@@ -6827,20 +4782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6fde449bd2963d394284ec46db8c647e6a5602d90601117b76752072ab54168"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-util 0.4.3",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.9.2",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "rayon",
 ]
 
 [[package]]
@@ -6854,46 +4801,15 @@ dependencies = [
 
 [[package]]
 name = "p3-mds"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-dft 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-symmetric 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "p3-mds"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3895055d735ac96d010747b3aaabd4c2645b9fd80226960550318db2e25afb75"
 dependencies = [
- "p3-dft 0.4.3",
- "p3-field 0.4.3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "p3-dft",
+ "p3-field",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.9.2",
-]
-
-[[package]]
-name = "p3-merkle-tree"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-commit 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-symmetric 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
- "serde",
- "tracing",
 ]
 
 [[package]]
@@ -6903,37 +4819,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e20f61ea816e94f83ed7b8134a5e98d0cad7bd6dff226bc1da17a5143c63cb"
 dependencies = [
  "itertools 0.14.0",
- "p3-commit 0.4.3",
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "p3-commit",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.9.2",
  "serde",
  "thiserror 2.0.17",
  "tracing",
-]
-
-[[package]]
-name = "p3-monty-31"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "p3-dft 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-mds 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-symmetric 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
- "serde",
- "tracing",
- "transpose",
 ]
 
 [[package]]
@@ -6943,15 +4838,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9fe0be661891af1f703ceaf57334fcbd540804988984dc2b500dd99740e7c81"
 dependencies = [
  "itertools 0.14.0",
- "num-bigint 0.4.6",
- "p3-dft 0.4.3",
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-mds 0.4.3",
- "p3-poseidon2 0.4.3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "num-bigint",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
  "paste",
  "rand 0.9.2",
  "serde",
@@ -6961,37 +4856,14 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "p3-field 0.1.0",
- "p3-mds 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "p3-poseidon"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548af7ff569975882bc411f653aba7d89a6d85813ca58ef922fd0b1ecb6b5866"
 dependencies = [
- "p3-field 0.4.3",
- "p3-mds 0.4.3",
- "p3-symmetric 0.4.3",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
  "rand 0.9.2",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "gcd",
- "p3-field 0.1.0",
- "p3-mds 0.1.0",
- "p3-symmetric 0.1.0",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -7000,27 +4872,11 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6fc2368447576283f8b3849a36095017f25addf06eab9e33b0ce7f96b0b99d"
 dependencies = [
- "p3-field 0.4.3",
- "p3-mds 0.4.3",
- "p3-symmetric 0.4.3",
- "p3-util 0.4.3",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.9.2",
-]
-
-[[package]]
-name = "p3-poseidon2-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "p3-air 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-poseidon2 0.1.0",
- "p3-util 0.1.0",
- "rand 0.8.5",
- "tikv-jemallocator",
- "tracing",
 ]
 
 [[package]]
@@ -7029,23 +4885,13 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a80481b023f74c0f8ded5058dab8054174e8060d82d400da7b67cf7f2f0a87bc"
 dependencies = [
- "p3-air 0.4.3",
- "p3-field 0.4.3",
- "p3-matrix 0.4.3",
- "p3-maybe-rayon 0.4.3",
- "p3-poseidon2 0.4.3",
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-poseidon2",
  "rand 0.9.2",
  "tracing",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.1.0",
- "serde",
 ]
 
 [[package]]
@@ -7055,33 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a14456a42a7d9e65f13999706f1bca2832175935169b3a54286e18331cf1d82f"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.4.3",
- "serde",
-]
-
-[[package]]
-name = "p3-uni-stark"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-air 0.1.0",
- "p3-challenger 0.1.0",
- "p3-commit 0.1.0",
- "p3-dft 0.1.0",
- "p3-field 0.1.0",
- "p3-matrix 0.1.0",
- "p3-maybe-rayon 0.1.0",
- "p3-util 0.1.0",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
+ "p3-field",
  "serde",
 ]
 
@@ -7165,17 +4985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "pasta_curves"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7212,47 +5021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac",
- "password-hash",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "pear"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
-dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi 1.0.1",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7266,16 +5034,6 @@ checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
 dependencies = [
  "memchr",
  "ucd-trie",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.12.1",
 ]
 
 [[package]]
@@ -7448,12 +5206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7480,9 +5232,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -7527,27 +5276,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
- "version_check",
- "yansi 1.0.1",
-]
-
-[[package]]
 name = "proptest"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
- "bitflags 2.10.0",
+ "bit-set",
+ "bit-vec",
+ "bitflags",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -7696,7 +5432,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -7725,18 +5461,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
+ "bitflags",
 ]
 
 [[package]]
@@ -7760,18 +5485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7784,9 +5497,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "repr_offset"
@@ -7799,63 +5512,22 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -7868,7 +5540,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tower",
@@ -7890,7 +5562,7 @@ dependencies = [
  "alloy-eips 1.1.2",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-trie 0.9.1",
  "auto_impl",
  "derive_more 2.0.1",
@@ -7908,7 +5580,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
  "alloy-genesis",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-trie 0.9.1",
  "bytes",
  "modular-bitfield",
@@ -7934,7 +5606,7 @@ version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -7959,7 +5631,7 @@ version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "reth-primitives-traits",
 ]
 
@@ -7981,7 +5653,7 @@ source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186d
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -7997,7 +5669,7 @@ source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186d
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "auto_impl",
  "once_cell",
 ]
@@ -8009,7 +5681,7 @@ source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186d
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde 1.1.2",
@@ -8027,7 +5699,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
  "alloy-evm",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
@@ -8048,7 +5720,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
  "alloy-evm",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -8066,7 +5738,7 @@ version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
  "alloy-evm",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "nybbles 0.4.6",
  "reth-storage-errors",
@@ -8081,7 +5753,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
  "alloy-evm",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -8094,7 +5766,7 @@ name = "reth-network-peers"
 version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "serde_with",
  "thiserror 2.0.17",
@@ -8122,7 +5794,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
  "alloy-genesis",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-trie 0.9.1",
@@ -8147,7 +5819,7 @@ name = "reth-prune-types"
 version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "derive_more 2.0.1",
  "thiserror 2.0.17",
 ]
@@ -8157,7 +5829,7 @@ name = "reth-revm"
 version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8169,7 +5841,7 @@ name = "reth-stages-types"
 version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "reth-trie-common",
 ]
 
@@ -8179,7 +5851,7 @@ version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "alloy-trie 0.9.1",
@@ -8204,7 +5876,7 @@ name = "reth-static-file-types"
 version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "derive_more 2.0.1",
  "serde",
  "strum 0.27.2",
@@ -8217,7 +5889,7 @@ source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186d
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -8238,7 +5910,7 @@ version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
@@ -8255,7 +5927,7 @@ source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186d
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.9.1",
  "auto_impl",
@@ -8276,7 +5948,7 @@ version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.9.1",
  "derive_more 2.0.1",
@@ -8291,7 +5963,7 @@ name = "reth-trie-sparse"
 version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.9.1",
  "auto_impl",
@@ -8307,7 +5979,7 @@ name = "reth-zstd-compressors"
 version = "1.8.2"
 source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186dee7a1ba0d51ea5416dc8fef3e46"
 dependencies = [
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -8789,27 +6461,11 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51187b852d9e458816a2e19c81f1dd6c924077e1a8fccd16e4f044f865f299d7"
-dependencies = [
- "alloy-primitives 0.4.2",
- "alloy-rlp",
- "auto_impl",
- "bitflags 2.10.0",
- "bitvec",
- "enumn",
- "hashbrown 0.14.5",
- "hex",
-]
-
-[[package]]
-name = "revm-primitives"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc2283ff87358ec7501956c5dd8724a6c2be959c619c4861395ae5e0054575f"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "enumn",
  "serde",
 ]
@@ -8820,7 +6476,7 @@ version = "19.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1588093530ec4442461163be49c433c07a3235d1ca6f6799fef338dacc50d3"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "num_enum",
  "serde",
 ]
@@ -8830,7 +6486,7 @@ name = "revm-primitives"
 version = "21.0.1"
 source = "git+https://github.com/scroll-tech/revm?tag=scroll-v91#10e11b985ed28bd383e624539868bcc3f613d77c"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "num_enum",
  "once_cell",
  "serde",
@@ -8842,7 +6498,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dd121f6e66d75ab111fb51b4712f129511569bc3e41e6067ae760861418bd8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "revm-bytecode 3.0.0",
  "revm-primitives 18.0.0",
  "serde",
@@ -8854,7 +6510,7 @@ version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0040c61c30319254b34507383ba33d85f92949933adf6525a2cede05d165e1fa"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "revm-bytecode 4.1.0",
  "revm-primitives 19.2.0",
  "serde",
@@ -8865,7 +6521,7 @@ name = "revm-state"
 version = "8.0.1"
 source = "git+https://github.com/scroll-tech/revm?tag=scroll-v91#10e11b985ed28bd383e624539868bcc3f613d77c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "revm-bytecode 7.0.1",
  "revm-primitives 21.0.1",
  "serde",
@@ -8909,7 +6565,7 @@ name = "risc0-ethereum-trie"
 version = "0.1.0"
 source = "git+https://github.com/risc0/risc0-ethereum#3aa137844818f0f44e6b2962b6eb958f26d04be7"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.8.1",
  "arrayvec",
@@ -8926,19 +6582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -8976,7 +6620,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -9045,23 +6689,11 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9072,18 +6704,9 @@ checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -9093,16 +6716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -9141,15 +6754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "sbv-core"
 version = "2.0.0"
 source = "git+https://github.com/scroll-tech/stateless-block-verifier?tag=scroll-v91.2#3a32848c9438432125751eae8837757f6b87562e"
@@ -9181,7 +6785,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
  "alloy-evm",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-serde 1.1.2",
@@ -9208,30 +6812,6 @@ dependencies = [
  "reth-trie",
  "risc0-ethereum-trie",
  "sbv-primitives",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if",
- "derive_more 1.0.0",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -9280,7 +6860,7 @@ source = "git+https://github.com/scroll-tech/reth?tag=scroll-v91.2#11d0a3f73186d
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.1.2",
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 1.1.2",
  "derive_more 2.0.1",
@@ -9296,10 +6876,10 @@ dependencies = [
  "clap",
  "eyre",
  "hex",
- "openvm-native-recursion 1.4.0",
- "openvm-sdk 1.4.0",
- "openvm-stark-sdk 1.2.1",
- "reqwest 0.12.24",
+ "openvm-native-recursion",
+ "openvm-sdk",
+ "openvm-stark-sdk",
+ "reqwest",
  "revm 24.0.0",
  "scroll-zkvm-verifier",
  "snark-verifier-sdk",
@@ -9310,15 +6890,15 @@ name = "scroll-zkvm-types"
 version = "0.8.0"
 source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
- "alloy-primitives 1.4.1",
- "base64 0.22.1",
+ "alloy-primitives",
+ "base64",
  "bincode",
  "eyre",
  "hex",
  "once_cell",
- "openvm-native-recursion 1.6.0",
- "openvm-sdk 1.6.0",
- "openvm-stark-sdk 1.4.0",
+ "openvm-native-recursion",
+ "openvm-sdk",
+ "openvm-stark-sdk",
  "sbv-primitives",
  "scroll-zkvm-types-base",
  "scroll-zkvm-types-batch",
@@ -9334,7 +6914,7 @@ name = "scroll-zkvm-types-base"
 version = "0.8.0"
 source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "alloy-serde 1.1.2",
  "serde",
  "sha2 0.10.9",
@@ -9346,15 +6926,15 @@ name = "scroll-zkvm-types-batch"
 version = "0.8.0"
 source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
- "alloy-primitives 1.4.1",
+ "alloy-primitives",
  "c-kzg",
  "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.14.0",
- "openvm 1.6.0",
- "openvm-algebra-guest 1.6.0",
- "openvm-ecc-guest 1.6.0",
+ "openvm",
+ "openvm-algebra-guest",
+ "openvm-ecc-guest",
  "openvm-pairing",
- "openvm-pairing-guest 1.6.0",
+ "openvm-pairing-guest",
  "openvm-sha2",
  "sbv-primitives",
  "scroll-zkvm-types-base",
@@ -9377,13 +6957,13 @@ version = "0.8.0"
 source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.8.0#5de3d673b78880c0c65756845b502b6cadf079a9"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 1.4.1",
- "alloy-sol-types 1.4.1",
+ "alloy-primitives",
+ "alloy-sol-types",
  "ecies",
  "hex-literal",
  "itertools 0.14.0",
  "k256 0.13.4 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
- "openvm-ecc-guest 1.6.0",
+ "openvm-ecc-guest",
  "openvm-pairing",
  "openvm-sha2",
  "p256 0.13.2 (git+https://github.com/openvm-org/openvm.git?tag=v1.6.0)",
@@ -9404,25 +6984,15 @@ dependencies = [
  "bincode",
  "eyre",
  "once_cell",
- "openvm-continuations 1.6.0",
- "openvm-native-recursion 1.6.0",
- "openvm-sdk 1.6.0",
+ "openvm-continuations",
+ "openvm-native-recursion",
+ "openvm-sdk",
  "scroll-zkvm-types",
  "serde",
  "serde_json",
  "sha256",
  "snark-verifier-sdk",
  "tracing",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -9487,7 +7057,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -9595,16 +7165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
- "serde",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9631,7 +7191,7 @@ version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -9664,17 +7224,6 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -9750,15 +7299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9767,12 +7307,6 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "siphasher"
@@ -9812,7 +7346,7 @@ dependencies = [
  "hex",
  "itertools 0.11.0",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "pairing 0.23.0",
@@ -9837,7 +7371,7 @@ dependencies = [
  "hex",
  "itertools 0.11.0",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "rand 0.8.5",
@@ -9849,36 +7383,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "solang-parser"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb9fa2fa2fa6837be8a2495486ff92e3ffe68a99b6eeba288e139efdd842457"
-dependencies = [
- "itertools 0.11.0",
- "lalrpop",
- "lalrpop-util",
- "phf 0.11.3",
- "thiserror 1.0.69",
- "unicode-xid",
 ]
 
 [[package]]
@@ -9923,18 +7433,6 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
-]
 
 [[package]]
 name = "strsim"
@@ -10011,39 +7509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "svm-rs"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
-dependencies = [
- "dirs",
- "fs2",
- "hex",
- "once_cell",
- "reqwest 0.11.27",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
- "zip",
-]
-
-[[package]]
-name = "svm-rs-builds"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa64b5e8eecd3a8af7cfc311e29db31a268a62d5953233d3e8243ec77a71c4e3"
-dependencies = [
- "build_const",
- "hex",
- "semver 1.0.27",
- "serde_json",
- "svm-rs",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10067,18 +7532,6 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4e6eed052a117409a1a744c8bda9c3ea6934597cf7419f791cb7d590871c4c"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "syn-solidity"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff790eb176cc81bb8936aed0f7b9f14fc4670069a2d371b3e3b0ecce908b2cb3"
@@ -10088,12 +7541,6 @@ dependencies = [
  "quote",
  "syn 2.0.110",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -10117,34 +7564,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -10173,18 +7599,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10279,26 +7694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10358,8 +7753,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "windows-sys 0.61.2",
 ]
 
@@ -10375,21 +7769,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls",
  "tokio",
 ]
 
@@ -10404,19 +7788,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "indexmap 2.12.1",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -10451,19 +7822,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.12.1",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -10473,7 +7831,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.13",
+ "winnow",
 ]
 
 [[package]]
@@ -10485,7 +7843,7 @@ dependencies = [
  "indexmap 2.12.1",
  "toml_datetime 0.7.3",
  "toml_parser",
- "winnow 0.7.13",
+ "winnow",
 ]
 
 [[package]]
@@ -10494,7 +7852,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "winnow 0.7.13",
+ "winnow",
 ]
 
 [[package]]
@@ -10512,7 +7870,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -10520,20 +7878,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "iri-string",
+ "http",
+ "http-body",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -10705,15 +8063,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10724,12 +8073,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -10828,16 +8171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10930,12 +8263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10950,15 +8277,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -11038,15 +8356,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -11070,21 +8379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -11122,12 +8416,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -11140,12 +8428,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -11155,12 +8437,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11188,12 +8464,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -11203,12 +8473,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11224,12 +8488,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -11239,12 +8497,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11260,30 +8512,11 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11306,18 +8539,6 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
@@ -11437,26 +8658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes 0.8.4",
- "byteorder",
- "bzip2",
- "constant_time_eq 0.1.5",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd 0.11.2+zstd.1.5.2",
-]
-
-[[package]]
 name = "zkhash"
 version = "0.2.0"
 source = "git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9#bb476b9ca38198cf5092487283c8b8c5d4317c4e"
@@ -11484,30 +8685,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ snark-verifier-sdk = { version = "=0.2.1", default-features = false, features = 
 ] }
 
 # scroll-tech/zkvm-prover
-scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "1839b4905bd920bf75de9c25997b8383029e021d" }
+scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.8.0" } 
 
 # miscellaneous
 clap = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ snark-verifier-sdk = { version = "=0.2.1", default-features = false, features = 
 ] }
 
 # scroll-tech/zkvm-prover
-scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.7.2" }
+scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "1839b4905bd920bf75de9c25997b8383029e021d" }
 
 # miscellaneous
 clap = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,14 @@ edition = "2024"
 [dependencies]
 
 # openvm
-openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0", default-features = false }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0", default-features = false, features = [
+openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.6.0", default-features = false }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.6.0", default-features = false, features = [
   "parallel",
   "evm-prove",
-  "evm-verify",
   "tco",
   "unprotected",
 ] }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.1" }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.4.0" }
 
 # revm
 revm = "=24.0.0"
@@ -24,6 +23,7 @@ snark-verifier-sdk = { version = "=0.2.1", default-features = false, features = 
   "loader_halo2",
   "halo2-axiom",
   "display",
+  "revm",
 ] }
 
 # scroll-tech/zkvm-prover

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ snark-verifier-sdk = { version = "=0.2.1", default-features = false, features = 
 ] }
 
 # scroll-tech/zkvm-prover
-scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.8.0" } 
+scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.8.0" }
 
 # miscellaneous
 clap = "4"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scroll Security Council Tools
 
-The repository offers tools for the Security Council to run and validate certain operations against Scroll's ZkVM [release](https://github.com/scroll-tech/zkvm-prover/releases/tag/v0.7.0)
+The repository offers tools for the Security Council to run and validate certain operations against Scroll's ZkVM [release](https://github.com/scroll-tech/zkvm-prover/releases/tag/v0.8.0)
 
 ## Setup
 
@@ -35,14 +35,16 @@ $ svm install 0.8.19
 $ solc --version
 ```
 
-In order to generate the verifier contract, we can either download the source from [`OpenVM`](https://github.com/openvm-org/openvm-solidity-sdk/blob/v1.4/src/v1.4/Halo2Verifier.sol) or re-compute it.
+* For `--recompute` only: install [Foundry](https://getfoundry.sh/) **v1.5.0**. The re-computed verifier source must be formatted with the same `forge fmt` version used by OpenVM to publish `Halo2Verifier.sol`, otherwise the embedded `solc` metadata hash (and thus the codehash) will not match the deployed verifier.
+
+In order to generate the verifier contract, we can either download the source from [`OpenVM`](https://github.com/openvm-org/openvm-solidity-sdk/blob/v1.6/src/v1.6/Halo2Verifier.sol) or re-compute it.
 
 * Download the verifier contract:
 ```shell
 $ cargo run --release -- generate-verifier
 ```
 
-* Re-compute the verifier contract (using [`OpenVM SDK`](https://github.com/openvm-org/openvm/blob/v1.4.0/crates/sdk/src/lib.rs#L804)):
+* Re-compute the verifier contract (using [`OpenVM SDK`](https://github.com/openvm-org/openvm/blob/v1.6.0/crates/sdk/src/lib.rs#L805)):
 ```shell
 # download SRS parameters
 $ bash scripts/download-params.sh
@@ -52,6 +54,8 @@ $ RUST_MIN_STACK=16777216 cargo run --release -- generate-verifier --recompute
 ```
 
 Note: Re-computation requires very large amounts of computation and memory (~200 GB). It took about 4 minutes on AWS c7a.24xlarge.
+
+Because `solc` embeds a metadata hash derived from the exact Solidity source text, the re-computed verifier must be formatted identically to the published `Halo2Verifier.sol` before compilation. `generate-verifier --recompute` therefore invokes `forge fmt` with the same formatter configuration used by OpenVM. For the resulting codehash to match the deployed verifier, the local `forge` binary should be **Foundry v1.5.0** (the version used to publish the OpenVM v1.6 verifier). Using a different `forge` version may produce a different codehash even though the verifier runtime logic is identical; in that case run `cargo run --release -- generate-verifier` (download mode) to obtain the exact on-chain codehash.
 
 ## Compute Digests
 

--- a/src/verifier/helpers.rs
+++ b/src/verifier/helpers.rs
@@ -1,26 +1,112 @@
+use openvm_native_recursion::halo2::utils::Halo2ParamsReader;
 use openvm_sdk::Sdk;
-use snark_verifier_sdk::snark_verifier::loader::evm::compile_solidity;
+use snark_verifier_sdk::{
+    SHPLONK,
+    evm::gen_evm_verifier_sol_code,
+    halo2::aggregation::AggregationCircuit,
+    snark_verifier::loader::evm::compile_solidity,
+};
 
 /// URL to download the Halo2 verifier's solidity code.
 ///
 /// Note the following:
 ///
-/// - OpenVM version is v1.4 (instead of v1.4.1) since patches don't include circuit-specific
-///   changes.
+/// - OpenVM version is v1.6 (instead of v1.6.x patches) since patches don't include
+///   circuit-specific changes.
 ///
-/// - The commit points to [tag=v1.4][tag]
+/// - The source points to [tag=v1.6][tag]
 ///
-/// [tag]: https://github.com/openvm-org/openvm-solidity-sdk/releases/tag/v1.4
-const URL_OPENVM_HALO2_VERIFIER: &str = "https://raw.githubusercontent.com/openvm-org/openvm-solidity-sdk/241058fb67da1439088f81633ea77b8c10015087/src/v1.4/Halo2Verifier.sol";
+/// [tag]: https://github.com/openvm-org/openvm-solidity-sdk/releases/tag/v1.6
+const URL_OPENVM_HALO2_VERIFIER: &str = "https://github.com/openvm-org/openvm-solidity-sdk/raw/refs/heads/main/src/v1.6/Halo2Verifier.sol";
+
+/// Foundry formatter configuration used by OpenVM when publishing
+/// `Halo2Verifier.sol`. `solc` embeds a metadata hash that depends on the exact
+/// source text, so re-generated code must be formatted identically before
+/// compilation in order to reproduce the on-chain codehash.
+const FOUNDRY_FMT_TOML: &str = r#"[fmt]
+sort_imports = true
+bracket_spacing = true
+int_types = "long"
+line_length = 120
+multiline_func_header = "attributes_first"
+number_underscore = "thousands"
+quote_style = "double"
+single_line_statement_blocks = "single"
+tab_width = 4
+wrap_comments = false
+"#;
+
+/// Format Solidity source with `forge fmt` using the canonical formatter config.
+fn format_solidity(sol_code: &str) -> eyre::Result<String> {
+    let temp_dir = std::env::temp_dir().join("scroll-sc-tools-verifier-fmt");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir)?;
+
+    let result = (|| {
+        let sol_path = temp_dir.join("Halo2Verifier.sol");
+        let config_path = temp_dir.join("foundry.toml");
+        std::fs::write(&config_path, FOUNDRY_FMT_TOML)?;
+        std::fs::write(&sol_path, sol_code)?;
+
+        let format_output = std::process::Command::new("forge")
+            .arg("fmt")
+            .arg(&sol_path)
+            .current_dir(&temp_dir)
+            .output();
+
+        match format_output {
+            Ok(output) if output.status.success() => {
+                std::fs::read_to_string(&sol_path).map_err(Into::into)
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                Err(eyre::eyre!("forge fmt failed: {stderr}"))
+            }
+            Err(e) => Err(eyre::eyre!("failed to spawn forge fmt: {e}")),
+        }
+    })();
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    result
+}
 
 /// Generate and return the EVM PLONK verifier's initcode.
 pub(crate) fn generate() -> eyre::Result<Vec<u8>> {
-    // Get the OpenVM SDK.
+    // The re-computed source must be formatted with the same Foundry version
+    // used by OpenVM to publish Halo2Verifier.sol, otherwise the embedded
+    // metadata hash (and thus the codehash) will differ.
+    match std::process::Command::new("forge").arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let version = String::from_utf8_lossy(&output.stdout);
+            if !version.contains("1.5.0") {
+                eprintln!(
+                    "Warning: local forge version is {}; for the re-computed codehash to match the deployed verifier, use Foundry v1.5.0.",
+                    version.trim()
+                );
+            }
+        }
+        _ => eprintln!("Warning: could not determine local forge version."),
+    }
+
+    // Get the OpenVM SDK with the standard RISC-V 32-bit configuration. The Halo2
+    // verifier only depends on the OpenVM aggregation circuit, which is the same
+    // for all Scroll circuits that use this VM configuration.
     let sdk = Sdk::riscv32();
+    let halo2_params_reader = sdk.halo2_params_reader();
+    let halo2_pk = sdk.halo2_pk();
+    let halo2_params = halo2_params_reader
+        .read_params(halo2_pk.wrapper.pinning.metadata.config_params.k);
 
-    // Generate and return the verifier's bytecode.
-    let sol_code = sdk.generate_halo2_verifier_solidity()?.halo2_verifier_code;
+    // Generate the verifier Solidity code using the same method as
+    // scroll-zkvm-prover's build-guest, then format it canonically before
+    // compiling so the resulting codehash matches the deployed verifier.
+    let sol_code = gen_evm_verifier_sol_code::<AggregationCircuit, SHPLONK>(
+        &halo2_params,
+        halo2_pk.wrapper.pinning.pk.get_vk(),
+        halo2_pk.wrapper.pinning.metadata.num_pvs.clone(),
+    );
 
+    let sol_code = format_solidity(&sol_code)?;
     Ok(compile_solidity(&sol_code))
 }
 


### PR DESCRIPTION
Upgrade to v0.8.0 version: https://github.com/scroll-tech/zkvm-prover/pull/254 (deployed on mainnet, but not merged and tagged yet).

## Verifier codehash fix

The previous `generate-verifier --recompute` implementation was based on OpenVM v1.4.0 and produced a codehash that did not match the verifier deployed at `0x96cbcC4333E172927fDa8B631C716d43E2FBA01C` (`0x6a74f16c472ea2698ee461daf35ffb62faaef6280d40390961daa181bc805663`). This PR aligns the tool with `zkvm-prover v0.8.0` / OpenVM v1.6.0:

- Bumps OpenVM dependencies to the versions used by `zkvm-prover v0.8.0`.
- Replaces the deprecated verifier generation path with the one used by `zkvm-prover/crates/build-guest`.
- Applies the canonical `forge fmt` configuration before compiling the re-computed verifier, so the `solc` metadata hash matches the published `Halo2Verifier.sol`.
- Documents the Foundry v1.5.0 requirement for `--recompute` to yield the exact on-chain codehash.

### Verification

```text
$ cargo run --release -- generate-verifier
0x6a74f16c472ea2698ee461daf35ffb62faaef6280d40390961daa181bc805663

$ RUST_MIN_STACK=16777216 cargo run --release -- generate-verifier --recompute
0x6a74f16c472ea2698ee461daf35ffb62faaef6280d40390961daa181bc805663
```

Both modes now produce the same codehash as the on-chain verifier.
